### PR TITLE
Fix: Update Docker image tags to use repository-based naming

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -340,7 +340,9 @@ jobs:
           context: .
           file: docker/mcp.Dockerfile
           push: ${{ github.event.inputs.skip_docker_push != 'true' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-mcp
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-mcp-${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -351,7 +353,21 @@ jobs:
           context: .
           file: docker/mcp-http-bridge.Dockerfile
           push: ${{ github.event.inputs.skip_docker_push != 'true' }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-mcp-http-bridge:main
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-mcp-http-bridge
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-mcp-http-bridge-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push Python CI image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/python-ci.Dockerfile
+          push: ${{ github.event.inputs.skip_docker_push != 'true' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-python-ci
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-python-ci-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
- Updates Docker image tagging strategy to properly differentiate multiple images under the single GitHub Container Registry namespace
- Ensures all images are published with unique, descriptive tags

## Changes
- **MCP Server**: Tags as `main-mcp` and `main-mcp-{SHA}`
- **MCP HTTP Bridge**: Tags as `main-mcp-http-bridge` and `main-mcp-http-bridge-{SHA}`
- **Python CI**: Tags as `main-python-ci` and `main-python-ci-{SHA}`

## Test Plan
- [x] YAML validation passes locally
- [ ] CI pipeline builds and pushes all images correctly
- [ ] Images are accessible from GHCR with proper tags

🤖 Generated with [Claude Code](https://claude.ai/code)