### PR TITLE
fix: force lowercase Docker image repository names

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -341,8 +341,8 @@ jobs:
           file: docker/mcp.Dockerfile
           push: ${{ github.event.inputs.skip_docker_push != 'true' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-mcp
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-mcp-${{ github.sha }}
+            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp
+            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -354,8 +354,8 @@ jobs:
           file: docker/mcp-http-bridge.Dockerfile
           push: ${{ github.event.inputs.skip_docker_push != 'true' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-mcp-http-bridge
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-mcp-http-bridge-${{ github.sha }}
+            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-http-bridge
+            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-http-bridge-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -366,8 +366,8 @@ jobs:
           file: docker/python-ci.Dockerfile
           push: ${{ github.event.inputs.skip_docker_push != 'true' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-python-ci
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-python-ci-${{ github.sha }}
+            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-python-ci
+            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-python-ci-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
- Changed all Docker image tags in main-ci.yml to use hardcoded lowercase repository names
- Replaced dynamic `${{ env.IMAGE_NAME }}` (which includes uppercase GitHub username) with `andrewaltimit/template-repo`
- Ensures compliance with Docker Hub naming requirements that only allow lowercase characters

## Test plan
- [ ] Verify GitHub Actions workflows pass
- [ ] Confirm Docker images can be built and pushed successfully
- [ ] Check that image names are properly lowercase in the registry

🤖 Generated with [Claude Code](https://claude.ai/code)