### PR TITLE
Disable Docker image pushes in CI workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -316,13 +316,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to registry
-        if: github.event.inputs.skip_docker_push != 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # Docker login disabled - no image pushes
+      # - name: Log in to registry
+      #   if: github.event.inputs.skip_docker_push != 'true'
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: ${{ env.REGISTRY }}
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
@@ -339,7 +340,7 @@ jobs:
         with:
           context: .
           file: docker/mcp.Dockerfile
-          push: ${{ github.event.inputs.skip_docker_push != 'true' }}
+          push: false  # Disabled - network unreliable
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-${{ github.sha }}
@@ -352,7 +353,7 @@ jobs:
         with:
           context: .
           file: docker/mcp-http-bridge.Dockerfile
-          push: ${{ github.event.inputs.skip_docker_push != 'true' }}
+          push: false  # Disabled - network unreliable
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-http-bridge
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-http-bridge-${{ github.sha }}
@@ -364,7 +365,7 @@ jobs:
         with:
           context: .
           file: docker/python-ci.Dockerfile
-          push: ${{ github.event.inputs.skip_docker_push != 'true' }}
+          push: false  # Disabled - network unreliable
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-python-ci
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-python-ci-${{ github.sha }}


### PR DESCRIPTION
## Summary
- Disabled all Docker image pushes in the main CI workflow to handle unreliable network conditions
- Images are still built but not pushed to any registry

## Changes
- Commented out Docker registry login step in `main-ci.yml`
- Set `push: false` for all Docker build-push-action steps:
  - MCP server image
  - MCP HTTP Bridge image  
  - Python CI image

## Test plan
- [ ] CI workflow runs successfully with image builds
- [ ] No attempts to push images to registry
- [ ] All other CI stages continue to work normally

🤖 Generated with [Claude Code](https://claude.ai/code)