### PR TITLE
Add remote MCP setup gist URLs for ComfyUI and AI Toolkit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,9 @@ GITHUB_TOKEN=your_github_personal_access_token
 # Run 'gemini' command once to authenticate
 
 # Optional: Remote Service URLs
+# ComfyUI MCP setup: https://gist.github.com/AndrewAltimit/f2a21b1a075cc8c9a151483f89e0f11e
 COMFYUI_SERVER_URL=http://192.168.0.152:8189
+# AI Toolkit MCP setup: https://gist.github.com/AndrewAltimit/2703c551eb5737de5a4c6767d3626cb8
 AI_TOOLKIT_SERVER_URL=http://192.168.0.152:8190
 
 # Optional: Database Configuration

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ This repository leverages **three AI agents** for development and automation:
 
 ### Remote Services
 
-- ComfyUI workflows
-- AI Toolkit LoRA training
+- **ComfyUI workflows** - [Setup guide](https://gist.github.com/AndrewAltimit/f2a21b1a075cc8c9a151483f89e0f11e)
+- **AI Toolkit LoRA training** - [Setup guide](https://gist.github.com/AndrewAltimit/2703c551eb5737de5a4c6767d3626cb8)
 
 ## Configuration
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -296,8 +296,7 @@ Access ComfyUI workflows for image generation.
 
 **Setup Instructions:**
 
-For detailed setup instructions for the ComfyUI MCP server, see:
-https://gist.github.com/AndrewAltimit/f2a21b1a075cc8c9a151483f89e0f11e
+For detailed setup instructions, see the [ComfyUI MCP Server Setup Guide](https://gist.github.com/AndrewAltimit/f2a21b1a075cc8c9a151483f89e0f11e).
 
 **Available Tools:**
 
@@ -317,8 +316,7 @@ Train LoRA models using AI Toolkit.
 
 **Setup Instructions:**
 
-For detailed setup instructions for the AI Toolkit MCP server, see:
-https://gist.github.com/AndrewAltimit/2703c551eb5737de5a4c6767d3626cb8
+For detailed setup instructions, see the [AI Toolkit MCP Server Setup Guide](https://gist.github.com/AndrewAltimit/2703c551eb5737de5a4c6767d3626cb8).
 
 **Available Tools:**
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -294,6 +294,11 @@ Compile LaTeX documents to various formats.
 
 Access ComfyUI workflows for image generation.
 
+**Setup Instructions:**
+
+For detailed setup instructions for the ComfyUI MCP server, see:
+https://gist.github.com/AndrewAltimit/f2a21b1a075cc8c9a151483f89e0f11e
+
 **Available Tools:**
 
 - `generate_image`: Generate images using workflows
@@ -309,6 +314,11 @@ COMFYUI_SERVER_URL=http://192.168.0.152:8189
 ### AI Toolkit Integration
 
 Train LoRA models using AI Toolkit.
+
+**Setup Instructions:**
+
+For detailed setup instructions for the AI Toolkit MCP server, see:
+https://gist.github.com/AndrewAltimit/2703c551eb5737de5a4c6767d3626cb8
 
 **Available Tools:**
 


### PR DESCRIPTION
## Summary
- Added gist URL links to MCP_TOOLS.md for both ComfyUI and AI Toolkit setup instructions
- Added setup guide links to README.md Remote Services section  
- Added gist URLs as comments in .env.example for easy reference

## Test plan
- [x] Verify all gist URLs are correct and accessible
- [x] Check that documentation formatting is preserved
- [x] Ensure CI checks pass (linting, formatting)

🤖 Generated with [Claude Code](https://claude.ai/code)