### PR TITLE
fix: add missing tools.py files for OpenCode and Crush MCP servers

### DIFF
--- a/tools/mcp/crush/tools.py
+++ b/tools/mcp/crush/tools.py
@@ -1,6 +1,8 @@
 """Crush MCP tools registry"""
 
 # Tool registry - exported for compatibility with CI tests
+# Tool functions are implemented and assigned by the MCP server at runtime.
+# This registry is for discovery and compatibility with CI checks.
 TOOLS = {
     "consult_crush": None,
     "clear_crush_history": None,

--- a/tools/mcp/crush/tools.py
+++ b/tools/mcp/crush/tools.py
@@ -1,0 +1,9 @@
+"""Crush MCP tools registry"""
+
+# Tool registry - exported for compatibility with CI tests
+TOOLS = {
+    "consult_crush": None,
+    "clear_crush_history": None,
+    "crush_status": None,
+    "toggle_crush_auto_consult": None,
+}

--- a/tools/mcp/opencode/tools.py
+++ b/tools/mcp/opencode/tools.py
@@ -1,6 +1,8 @@
 """OpenCode MCP tools registry"""
 
 # Tool registry - exported for compatibility with CI tests
+# Tool functions are implemented and assigned by the MCP server at runtime.
+# This registry is for discovery and compatibility with CI checks.
 TOOLS = {
     "consult_opencode": None,
     "clear_opencode_history": None,

--- a/tools/mcp/opencode/tools.py
+++ b/tools/mcp/opencode/tools.py
@@ -1,0 +1,9 @@
+"""OpenCode MCP tools registry"""
+
+# Tool registry - exported for compatibility with CI tests
+TOOLS = {
+    "consult_opencode": None,
+    "clear_opencode_history": None,
+    "opencode_status": None,
+    "toggle_opencode_auto_consult": None,
+}


### PR DESCRIPTION
## Summary
- Added missing `tools.py` files for OpenCode and Crush MCP servers
- Fixes import errors in main-ci.yml workflow that were preventing CI from passing
- Matches the pattern used by other MCP servers (Code Quality, Content Creation, Gaea2)

## Problem
The main-ci.yml workflow was failing with:
```
❌ Failed to import OpenCode server: No module named 'tools.mcp.opencode.tools'
❌ Failed to import Crush server: No module named 'tools.mcp.crush.tools'
```

## Solution
Created `tools.py` files for both servers that export a TOOLS dictionary with the available tool names. This matches the pattern used by other MCP servers and satisfies the CI import requirements.

## Test plan
- [x] Verified imports work locally
- [x] Ran format checks
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.ai/code)