### PR TITLE
Fix Docker multistage builds in CI pipeline

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -400,6 +400,7 @@ jobs:
           context: .
           file: docker/mcp-code-quality.Dockerfile
           push: false  # Disabled - network unreliable
+          load: true  # Load into Docker daemon for docker-compose
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-code-quality
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-code-quality-${{ github.sha }}
@@ -411,6 +412,7 @@ jobs:
           context: .
           file: docker/mcp-content.Dockerfile
           push: false  # Disabled - network unreliable
+          load: true  # Load into Docker daemon for docker-compose
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-content
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-content-${{ github.sha }}
@@ -422,6 +424,7 @@ jobs:
           context: .
           file: docker/mcp-gaea2.Dockerfile
           push: false  # Disabled - network unreliable
+          load: true  # Load into Docker daemon for docker-compose
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-gaea2
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-gaea2-${{ github.sha }}
@@ -433,6 +436,7 @@ jobs:
           context: .
           file: docker/mcp-http-bridge.Dockerfile
           push: false  # Disabled - network unreliable
+          load: true  # Load into Docker daemon for docker-compose
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-http-bridge
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-http-bridge-${{ github.sha }}
@@ -444,7 +448,9 @@ jobs:
           context: .
           file: docker/mcp-opencode.Dockerfile
           push: false  # Disabled - network unreliable
+          load: true  # Load into Docker daemon for multistage builds
           tags: |
+            template-repo-mcp-opencode:latest
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-opencode
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-opencode-${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -455,7 +461,9 @@ jobs:
           context: .
           file: docker/mcp-crush.Dockerfile
           push: false  # Disabled - network unreliable
+          load: true  # Load into Docker daemon for multistage builds
           tags: |
+            template-repo-mcp-crush:latest
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-crush
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-crush-${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -466,6 +474,10 @@ jobs:
           context: .
           file: docker/openrouter-agents.Dockerfile
           push: false  # Disabled - network unreliable
+          load: true  # Load into Docker daemon for docker-compose
+          build-args: |
+            OPENCODE_IMAGE=template-repo-mcp-opencode:latest
+            CRUSH_IMAGE=template-repo-mcp-crush:latest
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-openrouter-agents
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-openrouter-agents-${{ github.sha }}
@@ -477,6 +489,7 @@ jobs:
           context: .
           file: docker/python-ci.Dockerfile
           push: false  # Disabled - network unreliable
+          load: true  # Load into Docker daemon for docker-compose
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-python-ci
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-python-ci-${{ github.sha }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -587,6 +587,7 @@ jobs:
           context: .
           file: docker/mcp-code-quality.Dockerfile
           push: false
+          load: true  # Load into Docker daemon for docker-compose
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:pr-${{ github.event.pull_request.number }}-mcp-code-quality
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:pr-${{ github.event.pull_request.number }}-mcp-code-quality-${{ github.sha }}
@@ -598,6 +599,7 @@ jobs:
           context: .
           file: docker/mcp-content.Dockerfile
           push: false
+          load: true  # Load into Docker daemon for docker-compose
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:pr-${{ github.event.pull_request.number }}-mcp-content
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:pr-${{ github.event.pull_request.number }}-mcp-content-${{ github.sha }}
@@ -609,6 +611,7 @@ jobs:
           context: .
           file: docker/mcp-gaea2.Dockerfile
           push: false
+          load: true  # Load into Docker daemon for docker-compose
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:pr-${{ github.event.pull_request.number }}-mcp-gaea2
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:pr-${{ github.event.pull_request.number }}-mcp-gaea2-${{ github.sha }}
@@ -620,6 +623,7 @@ jobs:
           context: .
           file: docker/mcp-http-bridge.Dockerfile
           push: false
+          load: true  # Load into Docker daemon for docker-compose
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:pr-${{ github.event.pull_request.number }}-mcp-http-bridge
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:pr-${{ github.event.pull_request.number }}-mcp-http-bridge-${{ github.sha }}
@@ -631,6 +635,7 @@ jobs:
           context: .
           file: docker/python-ci.Dockerfile
           push: false
+          load: true  # Load into Docker daemon for docker-compose
           tags: |
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:pr-${{ github.event.pull_request.number }}-python-ci
             ${{ env.REGISTRY }}/andrewaltimit/template-repo:pr-${{ github.event.pull_request.number }}-python-ci-${{ github.sha }}


### PR DESCRIPTION
## Summary
- Fixed CI pipeline failures caused by Docker multistage builds trying to pull non-existent images from Docker Hub
- Added `load: true` flag to docker/build-push-action steps to ensure images are available in Docker daemon
- Configured proper local image tags and build arguments for dependency resolution

## Problem
The main CI pipeline was failing with error:
```
ERROR: failed to build: failed to solve: template-repo-mcp-crush:latest: 
failed to resolve source metadata for docker.io/library/template-repo-mcp-crush:latest: 
pull access denied, repository does not exist
```

This occurred because:
1. We use buildx with docker/build-push-action@v5
2. Without `load: true`, images stay in buildx cache only
3. The openrouter-agents Dockerfile uses multistage build expecting local images
4. Docker daemon couldn't find the images and tried pulling from Docker Hub

## Solution
- Added `load: true` to all Docker build steps in workflows
- Added local tags (template-repo-mcp-opencode:latest, template-repo-mcp-crush:latest)
- Passed build-args to specify local image references for multistage builds

## Test plan
- [x] Tested builds locally with the same tags
- [ ] CI pipeline should pass on this PR
- [ ] Main branch CI should work after merge

🤖 Generated with [Claude Code](https://claude.ai/code)