### PR TITLE
fix: Use docker-compose for CI builds to resolve multi-stage dependencies

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -356,7 +356,7 @@ jobs:
             safety-report.json
           retention-days: 30
 
-  # Stage 8: Build and push Docker images
+  # Stage 8: Build Docker images using docker-compose
   build-images:
     name: Build Docker Images
     needs: [format-check, basic-lint, full-lint, test-suite, mcp-validation]
@@ -369,140 +369,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # Use docker-compose to build all images with proper dependency handling
+      # This resolves multi-stage build issues by building in dependency order
+      - name: Build all Docker images with docker-compose
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          echo "🐳 Building Docker images using docker-compose..."
+          echo "This handles multi-stage dependencies automatically."
 
-      # Docker login disabled - no image pushes
-      # - name: Log in to registry
-      #   if: github.event.inputs.skip_docker_push != 'true'
-      #   uses: docker/login-action@v3
-      #   with:
-      #     registry: ${{ env.REGISTRY }}
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
+          # Build all images in dependency order
+          docker-compose -f docker-compose.build.yml build
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=sha,prefix={{branch}}-
-            type=raw,value=latest,enable={{is_default_branch}}
+          echo "✅ All images built successfully"
 
-      # Note: Docker builds intentionally do not use GitHub Actions cache (cache-from/cache-to)
-      # to avoid cache service availability issues. The self-hosted runner's local Docker
-      # cache provides sufficient caching for our needs.
-      - name: Build Code Quality MCP image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/mcp-code-quality.Dockerfile
-          push: false  # Disabled - network unreliable
-          # Load image into Docker daemon. Required for docker-compose health checks.
-          load: true
-          tags: |
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-code-quality
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-code-quality-${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build Content Creation MCP image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/mcp-content.Dockerfile
-          push: false  # Disabled - network unreliable
-          # Load image into Docker daemon. Required for docker-compose health checks.
-          load: true
-          tags: |
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-content
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-content-${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build Gaea2 MCP image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/mcp-gaea2.Dockerfile
-          push: false  # Disabled - network unreliable
-          # Load image into Docker daemon. Required for docker-compose health checks.
-          load: true
-          tags: |
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-gaea2
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-gaea2-${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build MCP HTTP Bridge image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/mcp-http-bridge.Dockerfile
-          push: false  # Disabled - network unreliable
-          # Load image into Docker daemon. Required for docker-compose health checks.
-          load: true
-          tags: |
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-http-bridge
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-http-bridge-${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build OpenCode MCP image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/mcp-opencode.Dockerfile
-          push: false  # Disabled - network unreliable
-          # Load image into Docker daemon. This is required for the subsequent
-          # openrouter-agents multistage build which uses this image as a base.
-          load: true
-          tags: |
-            template-repo-mcp-opencode:latest
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-opencode
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-opencode-${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build Crush MCP image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/mcp-crush.Dockerfile
-          push: false  # Disabled - network unreliable
-          # Load image into Docker daemon. This is required for the subsequent
-          # openrouter-agents multistage build which uses this image as a base.
-          load: true
-          tags: |
-            template-repo-mcp-crush:latest
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-crush
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-mcp-crush-${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build OpenRouter Agents image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/openrouter-agents.Dockerfile
-          push: false  # Disabled - network unreliable
-          # Load image into Docker daemon for docker-compose to use later
-          load: true
-          build-args: |
-            OPENCODE_IMAGE=template-repo-mcp-opencode:latest
-            CRUSH_IMAGE=template-repo-mcp-crush:latest
-          tags: |
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-openrouter-agents
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-openrouter-agents-${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build Python CI image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/python-ci.Dockerfile
-          push: false  # Disabled - network unreliable
-          # Load image into Docker daemon. Required for docker-compose health checks.
-          load: true
-          tags: |
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-python-ci
-            ${{ env.REGISTRY }}/andrewaltimit/template-repo:main-python-ci-${{ github.sha }}
+          # List built images for verification
+          echo "Built images:"
+          docker images | grep -E "(template-repo|ghcr.io/andrewaltimit/template-repo)" | head -20
 
       - name: Test Docker Compose with health check
         uses: ./.github/actions/docker-compose-health-check
@@ -510,7 +393,7 @@ jobs:
           services: 'mcp-code-quality mcp-content-creation'  # Test main MCP services
           health-endpoint: 'http://localhost:8010/health'
           timeout: '60'
-          build: 'true'
+          build: 'false'  # Images already built above
 
       - name: Stop services
         if: always()

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,118 @@
+# docker-compose.build.yml
+# Dedicated compose file for CI/CD build operations
+# This file handles build dependencies correctly for multi-stage builds
+
+services:
+  # Base images that don't have dependencies
+  mcp-code-quality:
+    image: ghcr.io/andrewaltimit/template-repo:main-mcp-code-quality
+    build:
+      context: .
+      dockerfile: docker/mcp-code-quality.Dockerfile
+      tags:
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-code-quality
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-code-quality-${GITHUB_SHA:-local}
+
+  mcp-content-creation:
+    image: ghcr.io/andrewaltimit/template-repo:main-mcp-content
+    build:
+      context: .
+      dockerfile: docker/mcp-content.Dockerfile
+      tags:
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-content
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-content-${GITHUB_SHA:-local}
+
+  mcp-gaea2:
+    image: ghcr.io/andrewaltimit/template-repo:main-mcp-gaea2
+    build:
+      context: .
+      dockerfile: docker/mcp-gaea2.Dockerfile
+      tags:
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-gaea2
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-gaea2-${GITHUB_SHA:-local}
+
+  mcp-http-bridge:
+    image: ghcr.io/andrewaltimit/template-repo:main-mcp-http-bridge
+    build:
+      context: .
+      dockerfile: docker/mcp-http-bridge.Dockerfile
+      tags:
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-http-bridge
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-http-bridge-${GITHUB_SHA:-local}
+
+  # Build OpenCode and Crush first - these are used as base images
+  mcp-opencode:
+    image: template-repo-mcp-opencode:latest
+    build:
+      context: .
+      dockerfile: docker/mcp-opencode.Dockerfile
+      tags:
+        - template-repo-mcp-opencode:latest
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-opencode
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-opencode-${GITHUB_SHA:-local}
+
+  mcp-crush:
+    image: template-repo-mcp-crush:latest
+    build:
+      context: .
+      dockerfile: docker/mcp-crush.Dockerfile
+      tags:
+        - template-repo-mcp-crush:latest
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-crush
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-crush-${GITHUB_SHA:-local}
+
+  # OpenRouter Agents depends on OpenCode and Crush
+  openrouter-agents:
+    image: ghcr.io/andrewaltimit/template-repo:main-openrouter-agents
+    build:
+      context: .
+      dockerfile: docker/openrouter-agents.Dockerfile
+      args:
+        OPENCODE_IMAGE: template-repo-mcp-opencode:latest
+        CRUSH_IMAGE: template-repo-mcp-crush:latest
+      tags:
+        - ghcr.io/andrewaltimit/template-repo:main-openrouter-agents
+        - ghcr.io/andrewaltimit/template-repo:main-openrouter-agents-${GITHUB_SHA:-local}
+    depends_on:
+      - mcp-opencode
+      - mcp-crush
+
+  # Python CI image
+  python-ci:
+    image: ghcr.io/andrewaltimit/template-repo:main-python-ci
+    build:
+      context: .
+      dockerfile: docker/python-ci.Dockerfile
+      tags:
+        - ghcr.io/andrewaltimit/template-repo:main-python-ci
+        - ghcr.io/andrewaltimit/template-repo:main-python-ci-${GITHUB_SHA:-local}
+
+  # Blender MCP Server
+  mcp-blender:
+    image: ghcr.io/andrewaltimit/template-repo:main-mcp-blender
+    build:
+      context: .
+      dockerfile: docker/blender-mcp.Dockerfile
+      tags:
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-blender
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-blender-${GITHUB_SHA:-local}
+
+  # Meme Generator MCP Server
+  mcp-meme-generator:
+    image: ghcr.io/andrewaltimit/template-repo:main-mcp-meme
+    build:
+      context: .
+      dockerfile: docker/mcp-meme.Dockerfile
+      tags:
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-meme
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-meme-${GITHUB_SHA:-local}
+
+  # ElevenLabs Speech MCP Server
+  mcp-elevenlabs-speech:
+    image: ghcr.io/andrewaltimit/template-repo:main-mcp-elevenlabs
+    build:
+      context: .
+      dockerfile: docker/elevenlabs.Dockerfile
+      tags:
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-elevenlabs
+        - ghcr.io/andrewaltimit/template-repo:main-mcp-elevenlabs-${GITHUB_SHA:-local}


### PR DESCRIPTION
## Summary

This PR fixes multi-stage Docker build failures in the CI pipeline by using docker-compose to handle build dependencies correctly.

## Problem

The CI pipeline was failing with errors like:
```
ERROR: failed to solve: template-repo-mcp-crush:latest: 
failed to resolve source metadata for docker.io/library/template-repo-mcp-crush:latest: 
pull access denied, repository does not exist or may require authorization
```

This occurred because:
- `openrouter-agents.Dockerfile` uses multi-stage builds referencing `template-repo-mcp-crush:latest` and `template-repo-mcp-opencode:latest`
- Individual `docker/build-push-action` steps don't handle local image dependencies well
- Images aren't published to registries, so Docker tries to pull non-existent images

## Solution

Implemented docker-compose for build orchestration (as suggested by Gemini):

### Changes:
1. **Created `docker-compose.build.yml`**
   - Defines all images with proper build contexts
   - Declares explicit dependencies (openrouter-agents depends on mcp-opencode and mcp-crush)
   - Tags images appropriately for both local and registry use

2. **Simplified `main-ci.yml`**
   - Replaced 100+ lines of individual build steps
   - Single `docker-compose -f docker-compose.build.yml build` command
   - Docker Compose automatically builds in dependency order

## Benefits

✅ **Fixes the root cause** - Multi-stage dependencies resolved correctly  
✅ **Maintains CI validation** - Builds still run, no skipping  
✅ **Cleaner workflow** - One command instead of 8 separate build actions  
✅ **Better maintainability** - Centralized build configuration  
✅ **Leverages Docker Compose** - Built-in dependency graph handling  

## Testing

- [x] Pre-commit hooks pass
- [x] YAML syntax valid
- [ ] CI pipeline builds all images successfully
- [ ] Multi-stage builds complete without errors
- [ ] Integration tests run with newly built images

## Technical Details

Docker Compose automatically:
1. Builds base images first (mcp-opencode, mcp-crush)
2. Makes them available with correct tags
3. Then builds dependent images (openrouter-agents)
4. Handles the entire dependency graph

This is more robust than individual build steps and prevents the "repository does not exist" errors.