### PR TITLE
Fix Docker image naming issue in sleeper-detection-tests workflow

### DIFF
--- a/.github/workflows/sleeper-detection-tests.yml
+++ b/.github/workflows/sleeper-detection-tests.yml
@@ -16,6 +16,9 @@ on:
         type: boolean
         default: false
 
+env:
+  DOCKER_IMAGE_COMPOSE_NAME: template-repo-sleeper-eval-cpu
+
 jobs:
   # Build Docker image once and share across all jobs
   build-sleeper-image:
@@ -47,7 +50,7 @@ jobs:
           docker-compose build sleeper-eval-cpu
 
           # Tag it for this workflow
-          docker tag template-repo-sleeper-eval-cpu:latest $IMAGE_TAG
+          docker tag ${{ env.DOCKER_IMAGE_COMPOSE_NAME }}:latest $IMAGE_TAG
 
           echo "✅ Built and tagged image: $IMAGE_TAG"
 
@@ -70,7 +73,7 @@ jobs:
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
           # Ensure we're using the image from the build job
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} ${{ env.DOCKER_IMAGE_COMPOSE_NAME }}:latest
 
       - name: Run quick CPU tests
         run: |
@@ -128,7 +131,7 @@ jobs:
       - name: Use pre-built image
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} ${{ env.DOCKER_IMAGE_COMPOSE_NAME }}:latest
 
       - name: Run residual stream analysis
         run: |
@@ -171,7 +174,7 @@ jobs:
       - name: Use pre-built image
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} ${{ env.DOCKER_IMAGE_COMPOSE_NAME }}:latest
 
       - name: Run unit tests with coverage
         run: |
@@ -273,7 +276,7 @@ jobs:
       - name: Use pre-built image
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} ${{ env.DOCKER_IMAGE_COMPOSE_NAME }}:latest
 
       - name: Start API server
         run: |
@@ -333,7 +336,7 @@ jobs:
       - name: Use pre-built image
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} ${{ env.DOCKER_IMAGE_COMPOSE_NAME }}:latest
 
       - name: Run full comprehensive tests
         run: |
@@ -374,7 +377,7 @@ jobs:
       - name: Use pre-built image
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} ${{ env.DOCKER_IMAGE_COMPOSE_NAME }}:latest
 
       - name: Validate Jupyter notebooks
         run: |

--- a/.github/workflows/sleeper-detection-tests.yml
+++ b/.github/workflows/sleeper-detection-tests.yml
@@ -47,7 +47,7 @@ jobs:
           docker-compose build sleeper-eval-cpu
 
           # Tag it for this workflow
-          docker tag sleeper-eval-cpu:latest $IMAGE_TAG
+          docker tag template-repo-sleeper-eval-cpu:latest $IMAGE_TAG
 
           echo "✅ Built and tagged image: $IMAGE_TAG"
 

--- a/.github/workflows/sleeper-detection-tests.yml
+++ b/.github/workflows/sleeper-detection-tests.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
           # Ensure we're using the image from the build job
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
 
       - name: Run quick CPU tests
         run: |
@@ -128,7 +128,7 @@ jobs:
       - name: Use pre-built image
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
 
       - name: Run residual stream analysis
         run: |
@@ -171,7 +171,7 @@ jobs:
       - name: Use pre-built image
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
 
       - name: Run unit tests with coverage
         run: |
@@ -273,7 +273,7 @@ jobs:
       - name: Use pre-built image
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
 
       - name: Start API server
         run: |
@@ -333,7 +333,7 @@ jobs:
       - name: Use pre-built image
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
 
       - name: Run full comprehensive tests
         run: |
@@ -374,7 +374,7 @@ jobs:
       - name: Use pre-built image
         run: |
           echo "🐳 Using pre-built image: ${{ needs.build-sleeper-image.outputs.image-tag }}"
-          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} sleeper-eval-cpu:latest
+          docker tag ${{ needs.build-sleeper-image.outputs.image-tag }} template-repo-sleeper-eval-cpu:latest
 
       - name: Validate Jupyter notebooks
         run: |


### PR DESCRIPTION
## Summary
- Fixed Docker image name mismatch that was causing CI failures on the main branch
- Updated the workflow to reference the correct image name after docker-compose build

🤖 Generated with [Claude Code](https://claude.ai/code)