### PR TITLE
feat(gemini): Add PR comment summarization for context retention

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -38,7 +38,7 @@
       "env": {
         "GEMINI_TIMEOUT": "300",
         "GEMINI_USE_CONTAINER": "false",
-        "_comment": "GEMINI_USE_CONTAINER is set to false to prevent docker-in-docker, as mcp-gemini itself runs in a container. Note: Don't specify GEMINI_MODEL - the CLI uses the default model automatically to avoid 404 errors"
+        "_comment": "GEMINI_USE_CONTAINER is set to false to prevent docker-in-docker, as mcp-gemini itself runs in a container. API key is set via GEMINI_API_KEY in docker-compose.yml from GOOGLE_API_KEY. Note: Don't specify GEMINI_MODEL - the CLI uses the default model automatically to avoid 404 errors"
       }
     },
     "opencode": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -371,11 +371,14 @@ services:
         GROUP_ID: "${GROUP_ID:-1000}"
     container_name: mcp-gemini
     volumes:
-      - ~/.gemini:/home/geminiuser/.gemini  # Mount host Gemini OAuth (needs write for session cache)
+      - ~/.gemini:/home/geminiuser/.gemini  # Mount host Gemini credentials directory
       - ./:/workspace:ro  # Mount workspace for file access (read-only)
     environment:
       - PYTHONUNBUFFERED=1
-      # Keep using OAuth (free tier) - just need to refresh token when expired
+      # Pass API key from .env file (CLI will use this over corrupted token file)
+      - GEMINI_API_KEY=${GOOGLE_API_KEY:-}
+      # Explicitly unset GOOGLE_API_KEY to avoid Vertex API confusion
+      - GOOGLE_API_KEY=
       - GEMINI_TIMEOUT=${GEMINI_TIMEOUT:-300}
       - GEMINI_USE_CONTAINER=false  # Disable nested containerization
       - HOME=/home/geminiuser  # Set home directory for .gemini access


### PR DESCRIPTION
## Summary

This PR enhances the Gemini PR review system with intelligent comment history summarization to prevent re-reporting false positives and respect admin decisions from previous discussions.

**Key Enhancement:**
- Gemini now analyzes all PR comment history before performing code reviews
- Extracts context about admin decisions, false positives, architectural agreements, and completed action items
- Injects this historical context into both chunked and complete diff analyses

**Changes:**
- `automation/review/gemini-pr-review.py`:
  - New `summarize_all_pr_comments()` function using Gemini Flash model for cost-effective summarization
  - New `get_all_pr_comments()` helper for fetching complete comment history
  - Enhanced `analyze_file_group()` and `analyze_complete_diff()` to accept comment summaries
  - Admin comments prioritized in summarization for decision tracking

- `docker-compose.yml`:
  - Improved API key handling: Pass `GEMINI_API_KEY` from `GOOGLE_API_KEY` environment variable
  - Explicitly unset `GOOGLE_API_KEY` in container to avoid Vertex API confusion

- `tools/mcp/gemini/gemini_integration.py`:
  - Enhanced CLI execution to support both `GOOGLE_API_KEY` and `GEMINI_API_KEY`
  - Improved stdin handling for multi-line prompts

- `.mcp.json`:
  - Updated documentation comment about API key configuration

**Benefits:**
- Prevents wasting tokens by re-reporting issues already identified as false positives
- Respects architectural decisions made by admin in previous reviews
- Builds institutional memory across multiple review cycles
- Reduces noise and improves review quality

## Test plan

- [ ] Test PR review on a PR with existing comment history
- [ ] Verify comment summarization extracts key context correctly
- [ ] Confirm historical context prevents re-reporting false positives
- [ ] Validate API key handling works in containerized environment
- [ ] Run full CI/CD pipeline to ensure code quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)