### PR TITLE
fix(sleeper-agents): Fix transformer_lens hook signature

### DIFF
--- a/packages/sleeper_agents/scripts/evaluation/comprehensive_test.py
+++ b/packages/sleeper_agents/scripts/evaluation/comprehensive_test.py
@@ -242,7 +242,7 @@ class TinyModelTester:
         # Test intervention at different layers
         for layer_idx in range(min(3, self.model.cfg.n_layers)):
             # Define intervention hook - zero out activations
-            def zero_hook(resid, _hook):
+            def zero_hook(resid, hook=None):
                 # Zero out 10% of activations randomly
                 mask = torch.rand_like(resid) > 0.9
                 return resid * (~mask).float()


### PR DESCRIPTION
## Summary
- Fixed  in sleeper_agents comprehensive test caused by incorrect hook function signature
- The  function was receiving  as a keyword argument from transformer_lens, but only accepted it as a positional parameter 
- Changed signature from  to 

## Test plan
- [ ] CI pipeline passes with the fix
- [ ] Comprehensive test suite completes without 

🤖 Generated with [Claude Code](https://claude.com/claude-code)