### PR TITLE
fix(runner): Add pre/post cleanup for Docker directory permissions

### DIFF
--- a/.github/workflows/board-agent-worker.yml
+++ b/.github/workflows/board-agent-worker.yml
@@ -167,6 +167,39 @@ jobs:
       stale-claims-cleaned: ${{ steps.work.outputs.stale-claims-cleaned }}
 
     steps:
+      # Fix Docker-created directory permissions BEFORE checkout
+      # Docker containers may create directories (e.g., outputs/mcp-content) with root ownership,
+      # which blocks checkout cleanup. This step must run FIRST.
+      - name: Fix Docker directory permissions (pre-checkout)
+        run: |
+          echo "::group::Fix Docker Directory Permissions"
+          # The workspace path for the runner
+          WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"
+
+          # Find and fix ownership of output directories that Docker may have created as root
+          # Patterns cover all MCP server output directories from docker-compose.yml
+          for pattern in "outputs" "output" "mcp-content" "mcp-memes" "mcp-gaea2" \
+                         "video-editor" "elevenlabs_speech" "blender" "evaluation_results" \
+                         ".agent-venv" "__pycache__" ".pytest_cache"; do
+            if command -v sudo &> /dev/null; then
+              find "$WORKSPACE" -type d -name "$pattern" 2>/dev/null | while IFS= read -r dir; do
+                if [ -d "$dir" ]; then
+                  echo "Fixing ownership: $dir"
+                  sudo chown -R "$(id -u):$(id -g)" "$dir" 2>/dev/null || true
+                fi
+              done
+            fi
+          done
+
+          # Also fix the outputs directory at workspace root if it exists
+          if [ -d "$WORKSPACE/outputs" ] && command -v sudo &> /dev/null; then
+            sudo chown -R "$(id -u):$(id -g)" "$WORKSPACE/outputs" 2>/dev/null || true
+            echo "Fixed: $WORKSPACE/outputs"
+          fi
+
+          echo "Permissions check complete"
+          echo "::endgroup::"
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -205,3 +238,33 @@ jobs:
           # This step just logs the JSON summary for downstream consumption
           echo "JSON Summary:"
           echo '${{ steps.work.outputs.summary-json }}' | jq . 2>/dev/null || echo '${{ steps.work.outputs.summary-json }}'
+
+      # Fix Docker-created directory permissions after agent execution
+      # Ensures subsequent runs won't have permission issues during checkout
+      - name: Fix Docker directory permissions (post-cleanup)
+        if: always()
+        run: |
+          echo "::group::Post-Cleanup: Fix Docker Directory Permissions"
+          WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"
+
+          # Fix ownership of output directories that Docker may have created
+          # Patterns cover all MCP server output directories from docker-compose.yml
+          for pattern in "outputs" "output" "mcp-content" "mcp-memes" "mcp-gaea2" \
+                         "video-editor" "elevenlabs_speech" "blender" "evaluation_results" \
+                         ".agent-venv" "__pycache__" ".pytest_cache"; do
+            if command -v sudo &> /dev/null; then
+              find "$WORKSPACE" -type d -name "$pattern" 2>/dev/null | while IFS= read -r dir; do
+                if [ -d "$dir" ]; then
+                  sudo chown -R "$(id -u):$(id -g)" "$dir" 2>/dev/null || true
+                fi
+              done
+            fi
+          done
+
+          # Fix the outputs directory at workspace root
+          if [ -d "$WORKSPACE/outputs" ] && command -v sudo &> /dev/null; then
+            sudo chown -R "$(id -u):$(id -g)" "$WORKSPACE/outputs" 2>/dev/null || true
+          fi
+
+          echo "Post-cleanup complete"
+          echo "::endgroup::"


### PR DESCRIPTION
## Summary

- Fixes runner lockup caused by Docker-created directories with root ownership
- Adds pre-checkout step to fix permissions before `actions/checkout` cleanup
- Adds post-cleanup step to ensure correct permissions for subsequent runs

## Problem

The scheduled agent work job creates directories like `outputs/mcp-content` via Docker containers. These directories are created with root ownership, which causes `actions/checkout@v4` to fail with:

```
Error: File was unable to be removed Error: EACCES: permission denied, rmdir '.../outputs/mcp-content'
```

This blocks ALL pipelines on the self-hosted runner until `_work` is manually cleared.

## Solution

Added two cleanup steps to `board-agent-worker.yml`:

1. **Pre-checkout**: Runs BEFORE checkout to fix ownership of existing Docker-created directories
2. **Post-cleanup**: Runs after agent execution (with `if: always()`) to prepare for subsequent runs

Both steps use `sudo chown` to fix ownership of directories matching patterns from docker-compose.yml.

## Test plan

- [ ] Trigger scheduled agent work job manually
- [ ] Verify pre-checkout step runs and fixes permissions
- [ ] Verify checkout completes successfully
- [ ] Verify post-cleanup step runs
- [ ] Run another pipeline to confirm no permission issues
