### PR TITLE
fix(sleeper_agents): Correct TransformerLens hook function signatures

### DIFF
--- a/packages/sleeper_agents/scripts/analysis/residual_analysis.py
+++ b/packages/sleeper_agents/scripts/analysis/residual_analysis.py
@@ -469,7 +469,8 @@ class ResidualStreamAnalyzer:
             for head in range(self.model.cfg.n_heads):
                 # Patch attention pattern from clean to corrupted
                 # Use default args to capture loop variables
-                def patch_attention(pattern, _hook, _layer=layer, _head=head):
+                # Note: TransformerLens passes 'hook' as a keyword argument
+                def patch_attention(pattern, *, hook=None, _layer=layer, _head=head):
                     clean_pattern = clean_cache[f"blocks.{_layer}.attn.hook_pattern"][0, _head]
                     # Handle different sequence lengths
                     min_seq_len = min(pattern.shape[-1], clean_pattern.shape[-1])
@@ -488,7 +489,8 @@ class ResidualStreamAnalyzer:
 
             # Test MLP importance
             # Use default arg to capture loop variable
-            def patch_mlp(mlp_out, _hook, _layer=layer):
+            # Note: TransformerLens passes 'hook' as a keyword argument
+            def patch_mlp(mlp_out, *, hook=None, _layer=layer):
                 clean_mlp = clean_cache[f"blocks.{_layer}.mlp.hook_post"]
                 # Handle different sequence lengths
                 if mlp_out.shape[1] != clean_mlp.shape[1]:


### PR DESCRIPTION
## Summary

- Fix TypeError in residual stream analysis caused by incorrect hook function signatures
- TransformerLens passes `hook` as a keyword argument, but `patch_attention` and `patch_mlp` were expecting it as a positional argument
- Changed signatures to use keyword-only arguments: `*, hook=None`

## Root Cause

The error occurred in the `path_patching_analysis` method at line 480:
```
TypeError: ResidualStreamAnalyzer.path_patching_analysis.<locals>.patch_attention() got an unexpected keyword argument 'hook'
```

TransformerLens's `run_with_hooks` calls hook functions with `hook(activation, hook=hook_point)`, but the hook functions were defined as:
```python
def patch_attention(pattern, _hook, _layer=layer, _head=head):
```

This signature expects `_hook` as a positional argument, causing the TypeError when TransformerLens passes it as `hook=...`.

## Fix

Changed the hook function signatures to use keyword-only arguments:
```python
def patch_attention(pattern, *, hook=None, _layer=layer, _head=head):
def patch_mlp(mlp_out, *, hook=None, _layer=layer):
```

The `*` forces all following parameters to be keyword-only, properly accepting the `hook=hook_point` kwarg.

## Test plan

- [x] Local CI passed (format, lint, tests)
- [ ] GitHub Actions CI validates the fix
- [ ] Residual stream analysis completes without TypeError

