### PR TITLE
feat(ci): Add GitHub release stage with Python wheels and PDF documentation

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -5,10 +5,17 @@ name: Main CI
 'on':
   push:
     branches: [main]
+    tags:
+      - 'v*'  # Trigger on version tags (e.g., v1.0.0, v2.1.3)
   workflow_dispatch:
     inputs:
       skip_docker_push:
         description: 'Skip pushing Docker images'
+        required: false
+        type: boolean
+        default: false
+      create_release:
+        description: 'Create a release (even without tag)'
         required: false
         type: boolean
         default: false
@@ -462,13 +469,237 @@ jobs:
           echo "- [ ] Verify health checks"
           echo "- [ ] Monitor error rates"
 
+  # Stage 12: Build Python wheels for release
+  build-python-wheels:
+    name: Build Python Wheels
+    needs: [test-suite, security-scan]
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.create_release == 'true'
+    runs-on: self-hosted
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          clean: true
+
+      - name: Build all package wheels
+        run: |
+          echo "📦 Building Python wheels for all packages..."
+          mkdir -p dist
+
+          # Build github-agents wheel
+          echo "Building github-agents..."
+          docker-compose run --rm python-ci bash -c "
+            cd packages/github_agents && \
+            pip install build && \
+            python -m build --wheel --outdir /app/dist
+          "
+
+          # Build economic-agents wheel
+          echo "Building economic-agents..."
+          docker-compose run --rm python-ci bash -c "
+            cd packages/economic_agents && \
+            pip install build && \
+            python -m build --wheel --outdir /app/dist
+          "
+
+          # Build sleeper-agents wheel
+          echo "Building sleeper-agents..."
+          docker-compose run --rm python-ci bash -c "
+            cd packages/sleeper_agents && \
+            pip install build && \
+            python -m build --wheel --outdir /app/dist
+          "
+
+          echo "Built wheels:"
+          ls -la dist/*.whl
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-wheels
+          path: dist/*.whl
+          retention-days: 90
+
+  # Stage 13: Build LaTeX documentation for release
+  build-latex-docs:
+    name: Build LaTeX Documentation
+    needs: [test-suite]
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.create_release == 'true'
+    runs-on: self-hosted
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          clean: true
+
+      - name: Create output directory
+        run: mkdir -p docs_output
+
+      - name: Build Sleeper Agents Framework Guide
+        run: |
+          echo "Building Sleeper_Agents_Framework_Guide.pdf..."
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "$(pwd)/packages/sleeper_agents/docs:/data" \
+            -v "$(pwd)/docs_output:/output" \
+            texlive/texlive:TL2024-historic \
+            bash -c "cd /data && latexmk -pdf -interaction=nonstopmode -output-directory=/output Sleeper_Agents_Framework_Guide.tex"
+
+      - name: Build AgentCore Memory Integration Guide
+        run: |
+          echo "Building AgentCore_Memory_Integration_Guide.pdf..."
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "$(pwd)/docs/integrations/ai-services:/data" \
+            -v "$(pwd)/docs_output:/output" \
+            texlive/texlive:TL2024-historic \
+            bash -c "cd /data && latexmk -pdf -interaction=nonstopmode -output-directory=/output AgentCore_Memory_Integration_Guide.tex"
+
+      - name: Build Virtual Character System Guide
+        run: |
+          echo "Building Virtual_Character_System_Guide.pdf..."
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "$(pwd)/docs/integrations/ai-services:/data" \
+            -v "$(pwd)/docs_output:/output" \
+            texlive/texlive:TL2024-historic \
+            bash -c "cd /data && latexmk -pdf -interaction=nonstopmode -output-directory=/output Virtual_Character_System_Guide.tex"
+
+      - name: Build AI Agents Political Targeting Report
+        run: ./automation/ci-cd/build-latex-doc.sh ai-agents-political-targeting.tex
+
+      - name: Build AI Agents WMD Proliferation Report
+        run: ./automation/ci-cd/build-latex-doc.sh ai-agents-wmd-proliferation.tex
+
+      - name: List built PDFs
+        run: |
+          echo "Built PDFs:"
+          ls -la docs_output/*.pdf
+
+      - name: Upload PDF artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation-pdfs
+          path: docs_output/*.pdf
+          retention-days: 90
+
+      - name: Cleanup auxiliary files
+        if: always()
+        run: |
+          rm -rf docs_output/*.aux docs_output/*.log docs_output/*.toc \
+                 docs_output/*.out docs_output/*.fls docs_output/*.fdb_latexmk \
+                 2>/dev/null || true
+
+  # Stage 14: Create GitHub Release
+  create-release:
+    name: Create GitHub Release
+    needs: [build-python-wheels, build-latex-docs, build-images, integration-tests]
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.create_release == 'true'
+    runs-on: self-hosted
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-wheels
+          path: release-artifacts/wheels
+
+      - name: Download PDF artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: documentation-pdfs
+          path: release-artifacts/docs
+
+      - name: List release artifacts
+        run: |
+          echo "Release artifacts:"
+          find release-artifacts -type f | sort
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="v$(date +%Y.%m.%d)-$(echo ${{ github.sha }} | cut -c1-7)"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          cat << 'EOF' > release_notes.md
+          ## Release ${{ steps.version.outputs.version }}
+
+          ### Python Packages
+
+          This release includes wheels for the following Python packages:
+
+          | Package | Description |
+          |---------|-------------|
+          | `github-agents` | Automated agents for GitHub workflows |
+          | `economic-agents` | Autonomous economic agent simulation framework |
+          | `sleeper-agents` | Framework for creating and studying sleeper agents |
+
+          ### Documentation
+
+          PDF documentation included in this release:
+
+          - **Sleeper Agents Framework Guide** - Comprehensive guide to the sleeper agents detection framework
+          - **AgentCore Memory Integration Guide** - AWS Bedrock AgentCore memory integration documentation
+          - **Virtual Character System Guide** - AI agent embodiment and multimedia performance platform guide
+          - **AI Agents Political Targeting Report** - Risk assessment for AI agents in political targeting
+          - **AI Agents WMD Proliferation Report** - Risk assessment for AI agents in WMD proliferation
+
+          ### Installation
+
+          ```bash
+          # Install packages from wheels
+          pip install github_agents-*.whl
+          pip install economic_agents-*.whl
+          pip install sleeper_agents-*.whl
+          ```
+
+          ### Commit Information
+
+          - **Commit**: ${{ github.sha }}
+          - **Branch**: ${{ github.ref_name }}
+          EOF
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: Release ${{ steps.version.outputs.version }}
+          body_path: release_notes.md
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+          files: |
+            release-artifacts/wheels/*.whl
+            release-artifacts/docs/*.pdf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Final status notification
   notify:
     name: CI Summary
     needs: [
       format-check, basic-lint, full-lint, test-suite,
       mcp-validation, docs-build, sleeper-agents-tests,
-      security-scan, build-images, integration-tests, deploy
+      security-scan, build-images, integration-tests, deploy,
+      build-python-wheels, build-latex-docs, create-release
     ]
     if: always()
     runs-on: self-hosted
@@ -497,6 +728,9 @@ jobs:
           echo "| Docker Build | ${{ needs.build-images.result == 'success' && '✅' || needs.build-images.result == 'skipped' && '⏭️' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Integration Tests | ${{ needs.integration-tests.result == 'success' && '✅' || needs.integration-tests.result == 'skipped' && '⏭️' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Deploy | ${{ needs.deploy.result == 'success' && '✅' || needs.deploy.result == 'skipped' && '⏭️' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Python Wheels | ${{ needs.build-python-wheels.result == 'success' && '✅' || needs.build-python-wheels.result == 'skipped' && '⏭️' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| LaTeX Docs | ${{ needs.build-latex-docs.result == 'success' && '✅' || needs.build-latex-docs.result == 'skipped' && '⏭️' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GitHub Release | ${{ needs.create-release.result == 'success' && '✅' || needs.create-release.result == 'skipped' && '⏭️' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Overall status

--- a/README.md
+++ b/README.md
@@ -334,6 +334,22 @@ All workflows run on self-hosted runners for zero-cost operation.
 - [GitHub Environments Setup](docs/infrastructure/github-environments.md)
 - [Containerized CI](docs/infrastructure/containerization.md)
 
+## Reports & PDF Documentation
+
+Technical reports and guides are available as PDFs, automatically built from LaTeX source and published with each release.
+
+| Document | PDF Download | Source |
+|----------|--------------|--------|
+| **Sleeper Agents Framework Guide** | [Latest Release](https://github.com/AndrewAltimit/template-repo/releases/latest) | [LaTeX Source](packages/sleeper_agents/docs/Sleeper_Agents_Framework_Guide.tex) |
+| **AgentCore Memory Integration Guide** | [Latest Release](https://github.com/AndrewAltimit/template-repo/releases/latest) | [LaTeX Source](docs/integrations/ai-services/AgentCore_Memory_Integration_Guide.tex) |
+| **Virtual Character System Guide** | [Latest Release](https://github.com/AndrewAltimit/template-repo/releases/latest) | [LaTeX Source](docs/integrations/ai-services/Virtual_Character_System_Guide.tex) |
+| **AI Agents Political Targeting Report** | [Latest Release](https://github.com/AndrewAltimit/template-repo/releases/latest) | [LaTeX Source](docs/projections/latex/ai-agents-political-targeting.tex) |
+| **AI Agents WMD Proliferation Report** | [Latest Release](https://github.com/AndrewAltimit/template-repo/releases/latest) | [LaTeX Source](docs/projections/latex/ai-agents-wmd-proliferation.tex) |
+
+**Build Status**: [![Build Documentation](https://github.com/AndrewAltimit/template-repo/actions/workflows/build-docs.yml/badge.svg)](https://github.com/AndrewAltimit/template-repo/actions/workflows/build-docs.yml)
+
+PDFs are compiled using the [texlive/texlive:TL2024-historic](https://hub.docker.com/r/texlive/texlive) Docker image. Individual PDF artifacts are also available from the [Build Documentation workflow](https://github.com/AndrewAltimit/template-repo/actions/workflows/build-docs.yml).
+
 ## License
 
 This project is released under the [Unlicense](LICENSE) (public domain dedication).

--- a/docs/projections/README.md
+++ b/docs/projections/README.md
@@ -20,10 +20,14 @@ These projections serve defensive policy analysis:
 
 ## Reports
 
-| Report | Topic | Status |
-|--------|-------|--------|
-| [ai-agents-political-targeting.md](./ai-agents-political-targeting.md) | AI agents and political violence risk | Complete |
-| [ai-agents-wmd-proliferation.md](./ai-agents-wmd-proliferation.md) | AI agents and WMD proliferation risk | Complete |
+| Report | Topic | PDF | Source |
+|--------|-------|-----|--------|
+| AI Agents Political Targeting | AI agents and political violence risk | [Download PDF](https://github.com/AndrewAltimit/template-repo/releases/latest) | [Markdown](./ai-agents-political-targeting.md) \| [LaTeX](./latex/ai-agents-political-targeting.tex) |
+| AI Agents WMD Proliferation | AI agents and WMD proliferation risk | [Download PDF](https://github.com/AndrewAltimit/template-repo/releases/latest) | [Markdown](./ai-agents-wmd-proliferation.md) \| [LaTeX](./latex/ai-agents-wmd-proliferation.tex) |
+
+**Build Status**: [![Build Documentation](https://github.com/AndrewAltimit/template-repo/actions/workflows/build-docs.yml/badge.svg)](https://github.com/AndrewAltimit/template-repo/actions/workflows/build-docs.yml)
+
+PDFs are automatically compiled from LaTeX source and published with each [release](https://github.com/AndrewAltimit/template-repo/releases). Individual build artifacts are also available from the [Build Documentation workflow](https://github.com/AndrewAltimit/template-repo/actions/workflows/build-docs.yml).
 
 ## Methodology
 

--- a/docs/roadmaps/README.md
+++ b/docs/roadmaps/README.md
@@ -1,0 +1,89 @@
+# Development Roadmaps
+
+This directory contains implementation roadmaps and integration proposals for upcoming features and system enhancements.
+
+## Purpose
+
+These roadmaps serve as:
+
+1. **Technical planning documents** - Detailed implementation strategies
+2. **Architecture references** - System design and integration patterns
+3. **Progress tracking** - Current status and milestones
+4. **Knowledge preservation** - Capturing design decisions and rationale
+
+## Roadmaps
+
+| Roadmap | Description | Status | PDF |
+|---------|-------------|--------|-----|
+| [Virtual Character](./virtual-character-roadmap.md) | AI agent embodiment in virtual worlds (VRChat, Blender, Unity) | Active | [Download](https://github.com/AndrewAltimit/template-repo/releases/latest) |
+| [MCP Integration](./mcp-integration-roadmap.md) | Unified Expressive AI Agent System across MCP servers | Active | - |
+| [DGX Spark Integration](./dgx-spark-integration-roadmap.md) | Hybrid cognitive architecture with local GPU inference | Planning | - |
+| [ElevenLabs Improvement](./elevenlabs-improvement-roadmap.md) | Low-latency streaming for virtual character integration | Implemented | - |
+
+The Virtual Character System Guide PDF is automatically built from [LaTeX source](../integrations/ai-services/Virtual_Character_System_Guide.tex) and published with each release.
+
+## Roadmap Summaries
+
+### Virtual Character Roadmap
+
+Comprehensive implementation plan for the Virtual Character MCP server, enabling AI agents to embody avatars in virtual worlds:
+
+- **Plugin-based architecture** for VRChat, Blender, and Unity backends
+- **Event sequencing system** for synchronized audio/animation performances
+- **Multi-agent coordination** for collaborative virtual experiences
+- **Environmental awareness** through video feed integration
+
+### MCP Integration Roadmap
+
+Proposal for unifying four MCP servers into a coherent expressive AI agent system:
+
+| Component | Role |
+|-----------|------|
+| ElevenLabs Speech | Emotional voice synthesis with 50+ expression tags |
+| Virtual Character | Embodied avatar control with emotions and gestures |
+| Reaction Search | Semantic search for contextual reaction images |
+| AgentCore Memory | Persistent memory with semantic search |
+
+### DGX Spark Integration
+
+Hybrid cognitive architecture combining cloud reasoning with local GPU acceleration:
+
+| Component | Role |
+|-----------|------|
+| Claude API (Opus 4.5) | Primary reasoning - analysis, insights, long-term thinking |
+| DGX Spark (Local GPU) | Fast real-time processing - emotion, fillers, audio styling |
+| ElevenLabs | Voice synthesis with expression tags |
+| Virtual Character | Embodied avatar delivery |
+
+**Goal**: Sub-500ms immediate reactions while Claude thinks deeply.
+
+### ElevenLabs Improvement Roadmap
+
+Improvements to the ElevenLabs MCP for virtual character integration:
+
+- **Low-latency streaming** with <100ms time-to-first-audio
+- **WebSocket optimization** for real-time character animation
+- **Audio tag support** for expressive speech synthesis
+
+**Status**: Implemented in December 2025.
+
+## Related Documentation
+
+- [MCP Architecture](../mcp/README.md) - Overall MCP server design
+- [Virtual Character Documentation](../../tools/mcp/mcp_virtual_character/README.md) - Implementation details
+- [ElevenLabs Speech Documentation](../../tools/mcp/mcp_elevenlabs_speech/docs/README.md) - Speech synthesis reference
+- [AI Agents Overview](../agents/README.md) - Agent ecosystem documentation
+
+## Contributing
+
+New roadmaps should include:
+
+1. **Executive Summary** - High-level overview and goals
+2. **Current State Analysis** - What exists today
+3. **Proposed Architecture** - Technical design
+4. **Implementation Phases** - Milestone breakdown
+5. **Success Criteria** - How to measure completion
+
+---
+
+*Last updated: December 2025*


### PR DESCRIPTION
## Summary

- Add GitHub release automation stage to `main-ci.yml` workflow
- Build and publish Python wheels for all packages in `packages/`
- Build and publish PDFs from all LaTeX documents
- Update documentation with links to releases and PDF downloads

## Changes

### CI/CD (`main-ci.yml`)

**New Triggers:**
- Version tag trigger (`v*`) for automatic releases on `git tag v1.0.0`
- Manual `create_release` input for workflow_dispatch

**New Jobs:**
| Stage | Description |
|-------|-------------|
| `build-python-wheels` | Builds wheels for github-agents, economic-agents, sleeper-agents |
| `build-latex-docs` | Compiles all 5 LaTeX documents to PDF |
| `create-release` | Creates GitHub release with all artifacts attached |

### Documentation Updates

| File | Change |
|------|--------|
| `README.md` | New "Reports & PDF Documentation" section with download links |
| `docs/projections/README.md` | Added PDF column with release links and LaTeX source references |
| `docs/roadmaps/README.md` | New README indexing all roadmaps with PDF link for Virtual Character |

## Release Artifacts

Each release will include:

**Python Wheels:**
- `github_agents-*.whl`
- `economic_agents-*.whl`
- `sleeper_agents-*.whl`

**PDF Documentation:**
- Sleeper Agents Framework Guide
- AgentCore Memory Integration Guide
- Virtual Character System Guide
- AI Agents Political Targeting Report
- AI Agents WMD Proliferation Report

## Test plan

- [ ] Verify YAML syntax is valid (pre-commit hooks passed)
- [ ] Test release workflow by pushing a version tag after merge
- [ ] Verify PDF and wheel artifacts appear in GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
