### PR TITLE
feat(mcp): Add comprehensive tests for mcp_github_board and fix integration

### DIFF
--- a/tools/mcp/mcp_github_board/mcp_github_board/server.py
+++ b/tools/mcp/mcp_github_board/mcp_github_board/server.py
@@ -10,8 +10,8 @@ import sys
 import traceback
 from typing import Any, Dict, Optional
 
-# Add paths for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "packages" / "github_agents" / "src"))
+# Add paths for imports (5 parents: server.py -> mcp_github_board -> mcp_github_board -> mcp -> tools -> repo_root)
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent / "packages" / "github_agents" / "src"))
 # pylint: disable=wrong-import-position  # Imports must come after sys.path modification
 
 from github_agents.board.config import BoardConfig, load_config  # noqa: E402

--- a/tools/mcp/mcp_github_board/tests/conftest.py
+++ b/tools/mcp/mcp_github_board/tests/conftest.py
@@ -9,7 +9,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "packages" / "github_agents" / "src"))
+# 5 parents: conftest.py -> tests -> mcp_github_board -> mcp -> tools -> repo_root
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent / "packages" / "github_agents" / "src"))
 
 from github_agents.board.models import (
     AgentClaim,

--- a/tools/mcp/mcp_github_board/tests/test_server.py
+++ b/tools/mcp/mcp_github_board/tests/test_server.py
@@ -13,8 +13,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# Set up path before imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "packages" / "github_agents" / "src"))
+# Set up path before imports (5 parents: test_server.py -> tests -> mcp_github_board -> mcp -> tools -> repo_root)
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent / "packages" / "github_agents" / "src"))
 
 from github_agents.board.models import (
     BoardConfig,


### PR DESCRIPTION
## Summary
- Add 40 unit tests covering all MCP tools and server functionality for `mcp_github_board`
- Fix config loading to use shared `load_config()` from `github_agents.board.config`
- Fix token handling to use shared `get_github_token()` utility from `github_agents.utils.github`
- Remove duplicate assert statements in tool methods

## Test plan
- [x] All 40 new tests pass
- [x] Full CI suite passes (format, lint-basic, lint-full, test)
- [x] Pre-commit hooks pass

## Details

### Analysis Findings
The `mcp_github_board` MCP server properly delegates all business logic to `github_agents.board.BoardManager` with no code duplication - it's a clean wrapper layer that translates MCP tool calls into BoardManager method calls.

### Tests Added
Tests cover:
- Server initialization (with config file, env fallback, no token)
- All 11 MCP tools: `query_ready_work`, `claim_work`, `renew_claim`, `release_work`, `update_status`, `add_blocker`, `mark_discovered_from`, `get_issue_details`, `get_dependency_graph`, `list_agents`, `get_board_config`
- Health check functionality
- Error handling and edge cases
- Integration with BoardManager from github_agents
- Parameter validation

### Integration Fixes
- Config loading now uses `load_config()` instead of non-existent `BoardConfig.from_file()`
- Token handling now uses `get_github_token()` which checks both `GITHUB_TOKEN` and `GH_TOKEN`

Generated with [Claude Code](https://claude.com/claude-code)