### PR TITLE
ci(andrewaltimit-template-repo): add HOL ai-plugin-scanner workflow

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,39 @@
+name: Codex Plugin Scanner CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Plugin Scanner
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Run scanner
+        continue-on-error: true
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@df9c8a41eefff30cc430344c2a32c7a96bf37645
+        with:
+          plugin_dir: "."
+          mode: scan
+          fail_on_severity: critical


### PR DESCRIPTION
This adds a non-blocking metadata check so plugin-related changes are easier to review in CI.

It only adds one workflow file, uses read-only permissions, and leaves runtime code and release flow alone.

Why it looked like a fit here:
- Integrate 20 MCP servers spanning code quality, content creation, 3D graphics, video editing, and speech synthesis
- All tools and CI/CD operations run in Docker containers for maximum portability
- Zero external dependencies - runs on any Linux system with Docker

The workflow only checks the existing metadata surface already in the repo.
Permissions: read-only. No secrets. No publish. No runtime changes.

No runtime code or release flow changes are included here, and the workflow can be removed cleanly if it does not fit your setup.
If you would rather fold it into an existing workflow instead of a dedicated file, I can adjust the branch.