### PR TITLE
fix: review-agent reliability — verified pushes + hallucination detection via stream-json

### DIFF
--- a/.agents.yaml
+++ b/.agents.yaml
@@ -112,7 +112,7 @@ model_overrides:
 
   # OpenRouter models (for openrouter agent)
   openrouter:
-    default_model: "qwen/qwen3.6-plus:free"
+    default_model: "qwen/qwen3.6-plus"
 
 # OpenRouter configuration (for future agents)
 openrouter:

--- a/.github/actions/pr-review-fix/action.yml
+++ b/.github/actions/pr-review-fix/action.yml
@@ -18,8 +18,14 @@ inputs:
 
 outputs:
   made_changes:
-    description: 'Whether changes were made'
+    description: 'Whether a commit was created by the agent'
     value: ${{ steps.agent-fix.outputs.made_changes || steps.skip.outputs.made_changes || 'false' }}
+  pushed:
+    description: 'Whether the commit was verifiably pushed to the remote'
+    value: ${{ steps.agent-fix.outputs.pushed || 'false' }}
+  commit_sha:
+    description: 'SHA of the commit created (empty if no changes)'
+    value: ${{ steps.agent-fix.outputs.commit_sha || '' }}
   iteration_count:
     description: 'Current iteration count'
     value: ${{ steps.iteration.outputs.iteration_count }}
@@ -108,6 +114,40 @@ runs:
           "$BRANCH_NAME" \
           "$ITERATION_COUNT" \
           "${{ inputs.max_iterations }}"
+
+    # If the agent committed locally but push verification failed, the commit
+    # is saved as a .patch file in $RUNNER_TEMP/review-agent-patches/. Upload
+    # it as an artifact so the work can be recovered manually rather than lost.
+    - name: Upload unpushed commit patch (on push failure)
+      if: always() && steps.agent-fix.outputs.made_changes == 'true' && steps.agent-fix.outputs.pushed == 'false'
+      uses: actions/upload-artifact@v4
+      with:
+        name: unpushed-review-commit-${{ inputs.pr_number }}-${{ github.run_id }}
+        path: ${{ runner.temp }}/review-agent-patches/*.patch
+        if-no-files-found: warn
+        retention-days: 14
+
+    - name: Report push status to job summary
+      if: always() && steps.iteration.outputs.should_skip != 'true'
+      shell: bash
+      env:
+        MADE_CHANGES: ${{ steps.agent-fix.outputs.made_changes }}
+        PUSHED: ${{ steps.agent-fix.outputs.pushed }}
+        COMMIT_SHA: ${{ steps.agent-fix.outputs.commit_sha }}
+      run: |
+        {
+          echo "## Review Response Agent"
+          if [ "$MADE_CHANGES" = "true" ] && [ "$PUSHED" = "true" ]; then
+            echo "- **Status:** changes pushed"
+            echo "- **Commit:** \`$COMMIT_SHA\`"
+          elif [ "$MADE_CHANGES" = "true" ] && [ "$PUSHED" != "true" ]; then
+            echo "- **Status:** PUSH FAILED (commit created but not on remote)"
+            echo "- **Commit:** \`$COMMIT_SHA\`"
+            echo "- Patch artifact uploaded for recovery"
+          else
+            echo "- **Status:** no changes — no commit created"
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Cleanup output directories
       if: always()

--- a/.github/actions/pr-review-fix/action.yml
+++ b/.github/actions/pr-review-fix/action.yml
@@ -127,6 +127,18 @@ runs:
         if-no-files-found: warn
         retention-days: 14
 
+    # Always upload Claude's raw stream-json output. This gives us structured
+    # tool_use events for post-mortem when the agent hallucinates (claims fixes
+    # without actually editing files), and is cheap when nothing went wrong.
+    - name: Upload Claude stream logs
+      if: always() && steps.iteration.outputs.should_skip != 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: review-agent-claude-logs-${{ inputs.pr_number }}-${{ github.run_id }}
+        path: ${{ runner.temp }}/review-agent-logs/*.jsonl
+        if-no-files-found: ignore
+        retention-days: 14
+
     - name: Report push status to job summary
       if: always() && steps.iteration.outputs.should_skip != 'true'
       shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ You are working alongside four other AI agents:
 3. **Crush** - Code generation via OpenRouter
 4. ~~**Gemini CLI**~~ - ~~Automated PR code reviews~~ **DISABLED** -- Google updated its AI principles (Feb 2026) to allow mass surveillance and autonomous weapons use cases. All Gemini integrations are disabled.
 5. **GitHub Copilot** - Code review suggestions in PRs
-6. **OpenRouter** - PR code review via Qwen model (qwen/qwen3.6-plus:free)
+6. **OpenRouter** - PR code review via Qwen model (qwen/qwen3.6-plus)
 
 Your role as Claude Code is the primary development assistant. **Anthropic models are the recommended default** for all AI operations.
 

--- a/review-profiles.yaml
+++ b/review-profiles.yaml
@@ -78,7 +78,7 @@ profiles:
   openrouter-general:
     display_name: "General Review"
     agent: openrouter
-    model: "qwen/qwen3.6-plus:free"
+    model: "qwen/qwen3.6-plus"
     focus: "General code quality, logic errors, edge cases"
     instructions: |
       You are a GENERAL code reviewer providing a broad perspective. Focus on:

--- a/tools/rust/automation-cli/Cargo.lock
+++ b/tools/rust/automation-cli/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "gh-validator",
  "libc",
  "owo-colors",
  "predicates",
@@ -120,7 +121,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -135,6 +136,15 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -252,10 +262,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -395,6 +434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +464,21 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "gh-validator"
+version = "0.1.0"
+dependencies = [
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_yaml",
+ "sha2",
+ "thiserror 1.0.69",
+ "ureq",
+ "url",
+ "wrapper-common",
 ]
 
 [[package]]
@@ -1113,7 +1177,9 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1259,6 +1325,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,11 +1464,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1547,6 +1644,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1666,21 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -1593,6 +1711,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -1694,6 +1818,24 @@ checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1927,6 +2069,18 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "wrapper-common"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "writeable"

--- a/tools/rust/automation-cli/Cargo.toml
+++ b/tools/rust/automation-cli/Cargo.toml
@@ -44,6 +44,11 @@ chrono = { version = "0.4", features = ["serde"] }
 # Terminal colors
 owo-colors = "4.0"
 
+# Secret masking shared with gh-validator wrapper. Used to redact stream-json
+# logs and unpushed-commit patches before they are uploaded as workflow
+# artifacts. Loads `.secrets.yaml` from the repo root.
+gh-validator = { path = "../gh-validator" }
+
 [dev-dependencies]
 tempfile = "3.10"
 assert_cmd = "2.0"

--- a/tools/rust/automation-cli/src/commands/review/respond.rs
+++ b/tools/rust/automation-cli/src/commands/review/respond.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Result, bail};
 use clap::Args;
+use gh_validator::{SecretMasker, load_config as load_secrets_config};
 
 use super::trust::{TrustConfig, TrustLevel};
 use crate::shared::{output, process, project};
@@ -404,7 +405,19 @@ fn parse_ls_remote_sha(output: &str) -> Option<String> {
 
 /// Persist the unpushed commit as a `.patch` file in `$RUNNER_TEMP/review-agent-patches/`
 /// so the workflow can upload it as an artifact for manual recovery.
+///
+/// The patch is masked through `gh-validator`'s `SecretMasker` (same `.secrets.yaml`
+/// as PR-comment masking) before hitting disk. We do NOT structurally redact the
+/// patch the way we do the stream log — the patch *is* the work to recover, and
+/// stripping its content would make it un-applicable. Pattern-based masking
+/// handles known secret formats without breaking the diff format.
+///
+/// Fail-closed: if `.secrets.yaml` is missing or unparseable, no patch is written.
 fn save_commit_patch(sha: &str) -> Result<String> {
+    let masker = load_secret_masker()?;
+    let raw_patch = process::run_capture("git", &["format-patch", "-1", "HEAD", "--stdout"])?;
+    let (masked_patch, _modified) = masker.mask(&raw_patch);
+
     let base = std::env::var("RUNNER_TEMP")
         .ok()
         .map(std::path::PathBuf::from)
@@ -413,8 +426,7 @@ fn save_commit_patch(sha: &str) -> Result<String> {
     std::fs::create_dir_all(&dir)?;
     let short_end = sha.len().min(12);
     let path = dir.join(format!("unpushed-{}.patch", &sha[..short_end]));
-    let patch = process::run_capture("git", &["format-patch", "-1", "HEAD", "--stdout"])?;
-    std::fs::write(&path, patch)?;
+    std::fs::write(&path, masked_patch)?;
     Ok(path.to_string_lossy().to_string())
 }
 
@@ -773,7 +785,22 @@ fn parse_claude_stream(stream: &str) -> (String, HashSet<String>) {
 /// Save the raw Claude stream-json output to a JSONL file under
 /// `$RUNNER_TEMP/review-agent-logs/`. The pr-review-fix workflow uploads this
 /// directory as the `review-agent-claude-logs` artifact.
+///
+/// Stream content is sanitized in two passes before hitting disk:
+/// 1. **Structural redaction** (`redact_tool_payloads`) — strips `Edit`/`Write`/
+///    `MultiEdit` content fields and `tool_result` content bodies entirely,
+///    keeping only metadata (tool name, file_path, byte counts) so we can still
+///    see *what* Claude was trying to do.
+/// 2. **Pattern masking** via `gh-validator`'s `SecretMasker`, loaded from
+///    `.secrets.yaml`. Catches anything the structural pass missed (e.g. tokens
+///    in Bash command strings or assistant text).
+///
+/// Fail-closed: if `.secrets.yaml` is missing or unparseable, no log is written.
 fn save_claude_stream_log(iteration: u32, content: &str) -> Result<String> {
+    let masker = load_secret_masker()?;
+    let redacted = redact_tool_payloads(content);
+    let (sanitized, _modified) = masker.mask(&redacted);
+
     let base = std::env::var("RUNNER_TEMP")
         .ok()
         .map(std::path::PathBuf::from)
@@ -785,8 +812,139 @@ fn save_claude_stream_log(iteration: u32, content: &str) -> Result<String> {
         .map(|d| d.as_secs())
         .unwrap_or(0);
     let path = dir.join(format!("claude-stream-iter{iteration}-{ts}.jsonl"));
-    std::fs::write(&path, content)?;
+    std::fs::write(&path, sanitized)?;
     Ok(path.to_string_lossy().to_string())
+}
+
+/// Load the shared `SecretMasker` from `.secrets.yaml` (same config the
+/// gh-validator wrapper uses for `gh pr comment` masking). Fail-closed: if the
+/// config is missing or invalid, return an error and let the caller skip the
+/// artifact rather than write an unmasked file.
+fn load_secret_masker() -> Result<SecretMasker> {
+    let config = load_secrets_config().map_err(|e| {
+        anyhow::anyhow!(
+            "fail-closed: cannot load .secrets.yaml for artifact masking ({e}); \
+             skipping artifact write to avoid leaking unmasked content"
+        )
+    })?;
+    Ok(SecretMasker::new(&config))
+}
+
+/// Walk a stream-json string line-by-line and strip content payloads from
+/// `tool_use` and `tool_result` blocks while preserving structure and
+/// identifying metadata. The result is still valid JSONL — every line either
+/// stays as-is (non-JSON, system events, etc.) or is re-serialized after
+/// in-place mutation.
+///
+/// Fields redacted:
+/// - `tool_use.input.old_string` / `new_string` / `content` → `<redacted: N chars>`
+/// - `tool_use.input.edits[].old_string` / `new_string` (MultiEdit) → same
+/// - `tool_result.content` (string form OR array of `{type:"text",text:"..."}`)
+///
+/// Fields kept:
+/// - `tool_use.name`, `id`, `input.file_path`, `input.command`, `input.pattern`,
+///   `input.url`, etc. — anything that describes *what* Claude was doing.
+/// - `text` blocks (assistant reasoning / summary marker)
+/// - `system` / `result` events
+fn redact_tool_payloads(stream: &str) -> String {
+    let mut out = String::with_capacity(stream.len());
+    for line in stream.lines() {
+        if line.trim().is_empty() {
+            out.push('\n');
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(mut event) => {
+                redact_event_in_place(&mut event);
+                match serde_json::to_string(&event) {
+                    Ok(s) => out.push_str(&s),
+                    Err(_) => out.push_str(line),
+                }
+            },
+            Err(_) => out.push_str(line),
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Mutate a single parsed JSON event to strip content payloads from any
+/// `tool_use` / `tool_result` blocks it contains.
+fn redact_event_in_place(event: &mut serde_json::Value) {
+    let Some(content) = event
+        .get_mut("message")
+        .and_then(|m| m.get_mut("content"))
+        .and_then(|c| c.as_array_mut())
+    else {
+        return;
+    };
+    for block in content.iter_mut() {
+        let Some(block_type) = block.get("type").and_then(|t| t.as_str()) else {
+            continue;
+        };
+        match block_type {
+            "tool_use" => redact_tool_use_input(block),
+            "tool_result" => redact_tool_result(block),
+            _ => {},
+        }
+    }
+}
+
+fn redact_tool_use_input(block: &mut serde_json::Value) {
+    let Some(input) = block.get_mut("input").and_then(|i| i.as_object_mut()) else {
+        return;
+    };
+    for key in ["old_string", "new_string", "content"] {
+        if let Some(v) = input.get_mut(key) {
+            *v = serde_json::Value::String(redacted_marker(v));
+        }
+    }
+    // MultiEdit nests an array of {old_string, new_string} edit specs.
+    if let Some(edits) = input.get_mut("edits").and_then(|e| e.as_array_mut()) {
+        for edit in edits.iter_mut() {
+            if let Some(obj) = edit.as_object_mut() {
+                for key in ["old_string", "new_string"] {
+                    if let Some(v) = obj.get_mut(key) {
+                        *v = serde_json::Value::String(redacted_marker(v));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn redact_tool_result(block: &mut serde_json::Value) {
+    let Some(content) = block.get_mut("content") else {
+        return;
+    };
+    match content {
+        // String form: replace whole string with marker.
+        serde_json::Value::String(_) => {
+            *content = serde_json::Value::String(redacted_marker(content));
+        },
+        // Array of content blocks (each may carry a `text` field). Replace
+        // each block's `text` with a marker so the structure is preserved.
+        serde_json::Value::Array(blocks) => {
+            for b in blocks.iter_mut() {
+                if let Some(obj) = b.as_object_mut()
+                    && let Some(text) = obj.get_mut("text")
+                {
+                    *text = serde_json::Value::String(redacted_marker(text));
+                }
+            }
+        },
+        _ => {},
+    }
+}
+
+/// Build a `<redacted: N chars>` marker that records the size of what was
+/// stripped, so debugging can still tell whether the field was empty or large.
+fn redacted_marker(value: &serde_json::Value) -> String {
+    let len = match value {
+        serde_json::Value::String(s) => s.len(),
+        other => other.to_string().len(),
+    };
+    format!("<redacted: {len} chars>")
 }
 
 fn extract_agent_summary(output: &str) -> String {
@@ -1112,6 +1270,97 @@ mod tests {
         let (text, edited) = parse_claude_stream("");
         assert!(text.is_empty());
         assert!(edited.is_empty());
+    }
+
+    #[test]
+    fn redact_tool_payloads_strips_edit_strings_keeps_metadata() {
+        let stream = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"src/foo.rs","old_string":"SECRET=ghp_abcdefghijklmnopqrstuvwxyz0123456789","new_string":"SECRET=redacted"}}]}}"#;
+        let out = redact_tool_payloads(stream);
+        assert!(out.contains("\"file_path\":\"src/foo.rs\""));
+        assert!(out.contains("\"name\":\"Edit\""));
+        assert!(out.contains("<redacted:"));
+        assert!(!out.contains("ghp_abcdefghijklmnopqrstuvwxyz0123456789"));
+        assert!(!out.contains("SECRET=redacted"));
+    }
+
+    #[test]
+    fn redact_tool_payloads_strips_write_content() {
+        let stream = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"out.txt","content":"line1\nline2\nsecret-here"}}]}}"#;
+        let out = redact_tool_payloads(stream);
+        assert!(out.contains("\"file_path\":\"out.txt\""));
+        assert!(!out.contains("secret-here"));
+        assert!(!out.contains("line1"));
+        assert!(out.contains("<redacted:"));
+    }
+
+    #[test]
+    fn redact_tool_payloads_strips_multiedit_array() {
+        let stream = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"MultiEdit","input":{"file_path":"a.rs","edits":[{"old_string":"FOO","new_string":"BAR"},{"old_string":"BAZ","new_string":"QUX"}]}}]}}"#;
+        let out = redact_tool_payloads(stream);
+        assert!(out.contains("\"file_path\":\"a.rs\""));
+        // Both edit specs should be present (structure preserved) but content stripped
+        assert!(!out.contains("\"FOO\""));
+        assert!(!out.contains("\"BAR\""));
+        assert!(!out.contains("\"BAZ\""));
+        assert!(!out.contains("\"QUX\""));
+        // Two redacted markers per edit, two edits = 4 markers minimum
+        assert_eq!(out.matches("<redacted:").count(), 4);
+    }
+
+    #[test]
+    fn redact_tool_payloads_strips_tool_result_string() {
+        let stream = r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"file contents with token=ghp_secrettoken1234567890"}]}}"#;
+        let out = redact_tool_payloads(stream);
+        assert!(out.contains("\"tool_use_id\":\"t1\""));
+        assert!(!out.contains("ghp_secrettoken1234567890"));
+        assert!(!out.contains("file contents"));
+        assert!(out.contains("<redacted:"));
+    }
+
+    #[test]
+    fn redact_tool_payloads_strips_tool_result_array_text() {
+        let stream = r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"text","text":"sensitive output"}]}]}}"#;
+        let out = redact_tool_payloads(stream);
+        assert!(out.contains("\"tool_use_id\":\"t1\""));
+        assert!(!out.contains("sensitive output"));
+        assert!(out.contains("<redacted:"));
+    }
+
+    #[test]
+    fn redact_tool_payloads_keeps_text_blocks_and_bash_command() {
+        let stream = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"I will run a command"},{"type":"tool_use","name":"Bash","input":{"command":"ls -la","description":"list"}}]}}"#;
+        let out = redact_tool_payloads(stream);
+        assert!(out.contains("I will run a command"));
+        assert!(out.contains("\"command\":\"ls -la\""));
+        // Bash inputs are NOT structurally redacted; SecretMasker handles
+        // pattern-based secret redaction afterward.
+        assert!(!out.contains("<redacted:"));
+    }
+
+    #[test]
+    fn redact_tool_payloads_passes_through_non_json_lines() {
+        let stream =
+            "not json line\n{\"type\":\"system\",\"subtype\":\"init\"}\nanother garbage line";
+        let out = redact_tool_payloads(stream);
+        assert!(out.contains("not json line"));
+        assert!(out.contains("\"system\""));
+        assert!(out.contains("another garbage line"));
+    }
+
+    #[test]
+    fn redact_tool_payloads_preserves_assistant_text_for_summary_extraction() {
+        // The summary marker lives in assistant text blocks; it MUST survive
+        // redaction so extract_agent_summary still works on the saved log.
+        let stream = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"---AGENT-SUMMARY-START---\n### Fixed Issues\n- foo\n---AGENT-SUMMARY-END---"}]}}"#;
+        let out = redact_tool_payloads(stream);
+        assert!(out.contains("---AGENT-SUMMARY-START---"));
+        assert!(out.contains("---AGENT-SUMMARY-END---"));
+    }
+
+    #[test]
+    fn redacted_marker_records_size() {
+        let v = serde_json::Value::String("12345".to_string());
+        assert_eq!(redacted_marker(&v), "<redacted: 5 chars>");
     }
 
     #[test]

--- a/tools/rust/automation-cli/src/commands/review/respond.rs
+++ b/tools/rust/automation-cli/src/commands/review/respond.rs
@@ -217,10 +217,18 @@ fn commit_and_push(args: &RespondArgs, summary: &str) -> Result<()> {
             Ok(())
         },
         Err(e) => {
+            // Re-read HEAD in case a rebase inside push_and_verify rewrote it.
+            let current_full = process::run_capture("git", &["rev-parse", "HEAD"])
+                .map(|s| s.trim().to_string())
+                .unwrap_or(commit_full);
+            let current_short = process::run_capture("git", &["rev-parse", "--short", "HEAD"])
+                .map(|s| s.trim().to_string())
+                .unwrap_or(commit_short);
+
             // The commit exists locally but did not reach the remote. Save a
             // format-patch so the workflow can upload it as an artifact and a
             // human (or a later iteration) can recover the lost work.
-            let patch_note = match save_commit_patch(&commit_full) {
+            let patch_note = match save_commit_patch(&current_full) {
                 Ok(path) => {
                     output::warn(&format!("Saved unpushed commit as patch: {path}"));
                     format!(
@@ -239,7 +247,7 @@ fn commit_and_push(args: &RespondArgs, summary: &str) -> Result<()> {
                 &format!(
                     "## Review Response Agent: push failed\n\
                      <!-- agent-metadata:type=review-fix-push-failure -->\n\n\
-                     Commit `{commit_short}` was created locally but did **not** reach the \
+                     Commit `{current_short}` was created locally but did **not** reach the \
                      remote after multiple verified retries.\n\n\
                      **Error:** `{e}`\n\n\
                      Manual intervention required. The earlier \"Changes committed, pushing...\" \
@@ -251,7 +259,7 @@ fn commit_and_push(args: &RespondArgs, summary: &str) -> Result<()> {
             // so downstream steps can distinguish "in flight" from "actually landed".
             project::set_github_output("made_changes", "true");
             project::set_github_output("pushed", "false");
-            project::set_github_output("commit_sha", &commit_full);
+            project::set_github_output("commit_sha", &current_full);
             Err(e)
         },
     }
@@ -318,7 +326,9 @@ fn push_and_verify(branch: &str, initial_sha: &str) -> Result<String> {
 }
 
 fn looks_like_non_fast_forward(msg: &str) -> bool {
-    msg.contains("non-fast-forward") || msg.contains("rejected") || msg.contains("fetch first")
+    msg.contains("non-fast-forward")
+        || msg.contains("fetch first")
+        || msg.contains("updates were rejected")
 }
 
 /// Fetch the branch and rebase local onto it. Returns the new HEAD SHA on
@@ -348,14 +358,14 @@ fn verify_remote_head(branch: &str, expected_sha: &str) -> Result<bool> {
     Ok(remote_sha == expected_sha)
 }
 
-/// Extract the first SHA from `git ls-remote` output.
-/// Format: `<full-sha>\trefs/heads/<branch>`
+/// Extract the branch SHA from `git ls-remote` output, preferring `refs/heads/`.
 fn parse_ls_remote_sha(output: &str) -> Option<String> {
+    let extract_sha = |line: &str| line.split_whitespace().next().map(|s| s.to_string());
     output
         .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().next())
-        .map(|s| s.to_string())
+        .find(|line| line.contains("refs/heads/"))
+        .and_then(extract_sha)
+        .or_else(|| output.lines().next().and_then(extract_sha))
 }
 
 /// Persist the unpushed commit as a `.patch` file in `$RUNNER_TEMP/review-agent-patches/`

--- a/tools/rust/automation-cli/src/commands/review/respond.rs
+++ b/tools/rust/automation-cli/src/commands/review/respond.rs
@@ -755,10 +755,13 @@ fn parse_claude_stream(stream: &str) -> (String, HashSet<String>) {
                             },
                             Some("tool_use") => {
                                 let name = block["name"].as_str().unwrap_or("");
-                                if FILE_MUTATING_TOOLS.contains(&name)
-                                    && let Some(path) = block["input"]["file_path"].as_str()
-                                {
-                                    edited.insert(path.to_string());
+                                if FILE_MUTATING_TOOLS.contains(&name) {
+                                    let path = block["input"]["file_path"]
+                                        .as_str()
+                                        .or_else(|| block["input"]["notebook_path"].as_str());
+                                    if let Some(p) = path {
+                                        edited.insert(p.to_string());
+                                    }
                                 }
                             },
                             _ => {},
@@ -809,7 +812,7 @@ fn save_claude_stream_log(iteration: u32, content: &str) -> Result<String> {
     std::fs::create_dir_all(&dir)?;
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
+        .map(|d| d.as_millis())
         .unwrap_or(0);
     let path = dir.join(format!("claude-stream-iter{iteration}-{ts}.jsonl"));
     std::fs::write(&path, sanitized)?;
@@ -1089,7 +1092,7 @@ fn post_hallucination_comment(
          <!-- agent-metadata:type=review-fix-hallucination:iteration={display_iter} -->\n\n\
          **Status:** Hallucination detected — no commit\n\n\
          > **Detection:** The agent's summary below claims to have applied fixes, \
-         > but Claude made **zero** file-mutating tool calls (`Edit` / `Write` / `MultiEdit`) \
+         > but Claude made **zero** file-mutating tool calls (`Edit` / `Write` / `MultiEdit` / `NotebookEdit`) \
          > during the run. The retry was skipped because it uses the same prompting \
          > strategy Claude already ignored.{log_note}\n\n\
          {summary}\n\n---\n\

--- a/tools/rust/automation-cli/src/commands/review/respond.rs
+++ b/tools/rust/automation-cli/src/commands/review/respond.rs
@@ -326,9 +326,10 @@ fn push_and_verify(branch: &str, initial_sha: &str) -> Result<String> {
 }
 
 fn looks_like_non_fast_forward(msg: &str) -> bool {
-    msg.contains("non-fast-forward")
-        || msg.contains("fetch first")
-        || msg.contains("updates were rejected")
+    let lower = msg.to_lowercase();
+    lower.contains("non-fast-forward")
+        || lower.contains("fetch first")
+        || lower.contains("updates were rejected")
 }
 
 /// Fetch the branch and rebase local onto it. Returns the new HEAD SHA on
@@ -365,7 +366,6 @@ fn parse_ls_remote_sha(output: &str) -> Option<String> {
         .lines()
         .find(|line| line.contains("refs/heads/"))
         .and_then(extract_sha)
-        .or_else(|| output.lines().next().and_then(extract_sha))
 }
 
 /// Persist the unpushed commit as a `.patch` file in `$RUNNER_TEMP/review-agent-patches/`
@@ -890,9 +890,15 @@ mod tests {
 
     #[test]
     fn parse_ls_remote_sha_first_line_only() {
-        // Multiple refs: take the first line's SHA.
+        // Multiple refs: take the first refs/heads/ line's SHA.
         let out = "aaa\trefs/heads/feature\nbbb\trefs/heads/main\n";
         assert_eq!(parse_ls_remote_sha(out).as_deref(), Some("aaa"));
+    }
+
+    #[test]
+    fn parse_ls_remote_sha_no_branch_ref() {
+        let out = "abc123\trefs/tags/v1.0\n";
+        assert_eq!(parse_ls_remote_sha(out), None);
     }
 
     #[test]

--- a/tools/rust/automation-cli/src/commands/review/respond.rs
+++ b/tools/rust/automation-cli/src/commands/review/respond.rs
@@ -352,7 +352,8 @@ fn rebase_onto_remote(branch: &str) -> Option<String> {
 }
 
 fn verify_remote_head(branch: &str, expected_sha: &str) -> Result<bool> {
-    let out = process::run_capture("git", &["ls-remote", "origin", branch])?;
+    let full_ref = format!("refs/heads/{branch}");
+    let out = process::run_capture("git", &["ls-remote", "origin", &full_ref])?;
     let remote_sha = parse_ls_remote_sha(&out)
         .ok_or_else(|| anyhow::anyhow!("ls-remote returned no ref for {branch}"))?;
     output::info(&format!("Remote origin/{branch} = {remote_sha}"));

--- a/tools/rust/automation-cli/src/commands/review/respond.rs
+++ b/tools/rust/automation-cli/src/commands/review/respond.rs
@@ -66,7 +66,7 @@ pub fn run(args: RespondArgs) -> Result<()> {
     if review_content.is_empty() {
         output::warn("No review feedback found, nothing to do");
         post_comment(args.pr_number, "No review feedback found to process.")?;
-        project::set_github_output("made_changes", "false");
+        report_no_commit();
         return Ok(());
     }
 
@@ -152,13 +152,13 @@ pub fn run(args: RespondArgs) -> Result<()> {
             };
             output::warn("Retry still produced no file changes");
             post_decision_comment(args.pr_number, args.iteration, false, "", &warning_summary)?;
-            project::set_github_output("made_changes", "false");
+            report_no_commit();
             return Ok(());
         }
 
         output::info("No changes to commit");
         post_decision_comment(args.pr_number, args.iteration, false, "", &summary)?;
-        project::set_github_output("made_changes", "false");
+        report_no_commit();
         return Ok(());
     }
 
@@ -184,39 +184,194 @@ fn commit_and_push(args: &RespondArgs, summary: &str) -> Result<()> {
     if diff_stat.trim().is_empty() {
         output::warn("Commit appears empty — no file changes in diff");
         post_decision_comment(args.pr_number, args.iteration, false, "", summary)?;
-        project::set_github_output("made_changes", "false");
+        report_no_commit();
         return Ok(());
     }
 
-    let commit_sha = process::run_capture("git", &["rev-parse", "--short", "HEAD"])?;
-    let commit_sha = commit_sha.trim();
+    let commit_full = process::run_capture("git", &["rev-parse", "HEAD"])?;
+    let commit_full = commit_full.trim().to_string();
+    let commit_short = process::run_capture("git", &["rev-parse", "--short", "HEAD"])?;
+    let commit_short = commit_short.trim().to_string();
 
     // Post comment BEFORE pushing — pushing triggers a new pipeline
     // run which cancels this one, so the comment must go first.
-    post_decision_comment(args.pr_number, args.iteration, true, commit_sha, summary)?;
+    post_decision_comment(args.pr_number, args.iteration, true, &commit_short, summary)?;
 
-    // Push (retries with backoff; post follow-up comment on failure)
+    // Push with verification: git push alone is unreliable (can exit 0 while the
+    // remote ref is unchanged). push_and_verify confirms via ls-remote that the
+    // commit actually landed, handles non-fast-forward by rebasing, and retries.
     output::header("Step 4: Pushing changes");
     let branch = args.branch.clone();
-    let push_result = temporarily_disable_pre_push_hook(|| {
-        process::run_with_retries("git", &["push", "origin", &branch], 3, 2)
-    });
+    let initial_sha = commit_full.clone();
+    let push_result = temporarily_disable_pre_push_hook(|| push_and_verify(&branch, &initial_sha));
 
-    if let Err(e) = push_result {
-        let _ = post_comment(
-            args.pr_number,
-            &format!(
-                "**Push failed** after retries: `{e}`\n\n\
-                 The commit exists locally but was not pushed. \
-                 Manual intervention required."
-            ),
-        );
-        return Err(e);
+    match push_result {
+        Ok(final_sha) => {
+            output::success(&format!(
+                "Push verified: origin/{} = {}",
+                args.branch, final_sha
+            ));
+            project::set_github_output("made_changes", "true");
+            project::set_github_output("pushed", "true");
+            project::set_github_output("commit_sha", &final_sha);
+            Ok(())
+        },
+        Err(e) => {
+            // The commit exists locally but did not reach the remote. Save a
+            // format-patch so the workflow can upload it as an artifact and a
+            // human (or a later iteration) can recover the lost work.
+            let patch_note = match save_commit_patch(&commit_full) {
+                Ok(path) => {
+                    output::warn(&format!("Saved unpushed commit as patch: {path}"));
+                    format!(
+                        "\n\nThe commit was saved as `{path}` for recovery; \
+                         this file is uploaded as the `unpushed-review-commit` workflow artifact."
+                    )
+                },
+                Err(pe) => {
+                    output::warn(&format!("Failed to save commit patch: {pe}"));
+                    String::new()
+                },
+            };
+
+            let _ = post_comment(
+                args.pr_number,
+                &format!(
+                    "## Review Response Agent: push failed\n\
+                     <!-- agent-metadata:type=review-fix-push-failure -->\n\n\
+                     Commit `{commit_short}` was created locally but did **not** reach the \
+                     remote after multiple verified retries.\n\n\
+                     **Error:** `{e}`\n\n\
+                     Manual intervention required. The earlier \"Changes committed, pushing...\" \
+                     comment should be considered superseded by this one.{patch_note}"
+                ),
+            );
+
+            // Still report made_changes=true (the commit was created) but pushed=false
+            // so downstream steps can distinguish "in flight" from "actually landed".
+            project::set_github_output("made_changes", "true");
+            project::set_github_output("pushed", "false");
+            project::set_github_output("commit_sha", &commit_full);
+            Err(e)
+        },
+    }
+}
+
+/// Mark the "no commit produced" state unambiguously in GitHub Actions outputs.
+fn report_no_commit() {
+    project::set_github_output("made_changes", "false");
+    project::set_github_output("pushed", "false");
+    project::set_github_output("commit_sha", "");
+}
+
+/// Push the current branch and verify via `git ls-remote` that the remote ref
+/// actually matches local HEAD. Handles silent push failures (command reports
+/// success but the remote ref is unchanged) and non-fast-forward rejections
+/// (fetch + rebase + recompute expected SHA). Returns the SHA that was
+/// verifiably landed on the remote.
+fn push_and_verify(branch: &str, initial_sha: &str) -> Result<String> {
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut last_err: Option<anyhow::Error> = None;
+    let mut current_sha = initial_sha.to_string();
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        output::info(&format!(
+            "Push attempt {attempt}/{MAX_ATTEMPTS} (expected sha: {current_sha})"
+        ));
+
+        let push_result = process::run("git", &["push", "origin", branch]);
+
+        match push_result {
+            Ok(()) => match verify_remote_head(branch, &current_sha) {
+                Ok(true) => return Ok(current_sha),
+                Ok(false) => {
+                    output::warn("Push reported success but remote ref is stale — retrying");
+                    last_err = Some(anyhow::anyhow!(
+                        "push verification failed: origin/{branch} does not match {current_sha}"
+                    ));
+                },
+                Err(e) => {
+                    output::warn(&format!("Could not verify remote ref: {e}"));
+                    last_err = Some(e);
+                },
+            },
+            Err(e) => {
+                let msg = format!("{e}");
+                output::warn(&format!("Push failed: {msg}"));
+                if looks_like_non_fast_forward(&msg)
+                    && let Some(new_sha) = rebase_onto_remote(branch)
+                {
+                    current_sha = new_sha;
+                    output::info(&format!("Rebased; new local HEAD = {current_sha}"));
+                }
+                last_err = Some(e);
+            },
+        }
+
+        if attempt < MAX_ATTEMPTS {
+            let delay = 2u64.pow(attempt.min(5));
+            std::thread::sleep(Duration::from_secs(delay));
+        }
     }
 
-    output::success(&format!("Changes pushed to branch: {}", args.branch));
-    project::set_github_output("made_changes", "true");
-    Ok(())
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("push failed: exhausted retries")))
+}
+
+fn looks_like_non_fast_forward(msg: &str) -> bool {
+    msg.contains("non-fast-forward") || msg.contains("rejected") || msg.contains("fetch first")
+}
+
+/// Fetch the branch and rebase local onto it. Returns the new HEAD SHA on
+/// success; aborts any in-progress rebase and returns None on failure so the
+/// caller can retry the bare push.
+fn rebase_onto_remote(branch: &str) -> Option<String> {
+    output::info("Non-fast-forward detected — fetching and rebasing");
+    if process::run("git", &["fetch", "origin", branch]).is_err() {
+        return None;
+    }
+    let remote_ref = format!("origin/{branch}");
+    if process::run("git", &["rebase", &remote_ref]).is_err() {
+        let _ = process::run("git", &["rebase", "--abort"]);
+        output::warn("Rebase failed — aborted, will retry bare push");
+        return None;
+    }
+    process::run_capture("git", &["rev-parse", "HEAD"])
+        .ok()
+        .map(|s| s.trim().to_string())
+}
+
+fn verify_remote_head(branch: &str, expected_sha: &str) -> Result<bool> {
+    let out = process::run_capture("git", &["ls-remote", "origin", branch])?;
+    let remote_sha = parse_ls_remote_sha(&out)
+        .ok_or_else(|| anyhow::anyhow!("ls-remote returned no ref for {branch}"))?;
+    output::info(&format!("Remote origin/{branch} = {remote_sha}"));
+    Ok(remote_sha == expected_sha)
+}
+
+/// Extract the first SHA from `git ls-remote` output.
+/// Format: `<full-sha>\trefs/heads/<branch>`
+fn parse_ls_remote_sha(output: &str) -> Option<String> {
+    output
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .map(|s| s.to_string())
+}
+
+/// Persist the unpushed commit as a `.patch` file in `$RUNNER_TEMP/review-agent-patches/`
+/// so the workflow can upload it as an artifact for manual recovery.
+fn save_commit_patch(sha: &str) -> Result<String> {
+    let base = std::env::var("RUNNER_TEMP")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    let dir = base.join("review-agent-patches");
+    std::fs::create_dir_all(&dir)?;
+    let short_end = sha.len().min(12);
+    let path = dir.join(format!("unpushed-{}.patch", &sha[..short_end]));
+    let patch = process::run_capture("git", &["format-patch", "-1", "HEAD", "--stdout"])?;
+    std::fs::write(&path, patch)?;
+    Ok(path.to_string_lossy().to_string())
 }
 
 fn collect_review_content(content: &mut String) -> Result<()> {
@@ -592,7 +747,7 @@ fn configure_git() -> Result<()> {
     Ok(())
 }
 
-fn temporarily_disable_pre_push_hook<F: FnOnce() -> Result<()>>(f: F) -> Result<()> {
+fn temporarily_disable_pre_push_hook<T, F: FnOnce() -> Result<T>>(f: F) -> Result<T> {
     let hook = Path::new(".git/hooks/pre-push");
     let disabled = Path::new(".git/hooks/pre-push.disabled");
     let had_hook = hook.exists();
@@ -702,6 +857,48 @@ mod tests {
         assert!(summary.contains("### Fixed Issues"));
         assert!(summary.contains("- a bug"));
         assert!(!summary.contains("preamble"));
+    }
+
+    #[test]
+    fn parse_ls_remote_sha_basic() {
+        let out = "abc123def456abc123def456abc123def456abcd\trefs/heads/main\n";
+        assert_eq!(
+            parse_ls_remote_sha(out).as_deref(),
+            Some("abc123def456abc123def456abc123def456abcd")
+        );
+    }
+
+    #[test]
+    fn parse_ls_remote_sha_empty() {
+        assert_eq!(parse_ls_remote_sha(""), None);
+    }
+
+    #[test]
+    fn parse_ls_remote_sha_whitespace_only() {
+        assert_eq!(parse_ls_remote_sha("   \n"), None);
+    }
+
+    #[test]
+    fn parse_ls_remote_sha_first_line_only() {
+        // Multiple refs: take the first line's SHA.
+        let out = "aaa\trefs/heads/feature\nbbb\trefs/heads/main\n";
+        assert_eq!(parse_ls_remote_sha(out).as_deref(), Some("aaa"));
+    }
+
+    #[test]
+    fn looks_like_non_fast_forward_matches() {
+        assert!(looks_like_non_fast_forward(
+            "! [rejected]        main -> main (non-fast-forward)"
+        ));
+        assert!(looks_like_non_fast_forward(
+            "error: failed to push some refs; updates were rejected"
+        ));
+        assert!(looks_like_non_fast_forward(
+            "hint: Updates were rejected because the tip of your current branch is behind -- fetch first"
+        ));
+        assert!(!looks_like_non_fast_forward(
+            "fatal: unable to access: could not resolve host"
+        ));
     }
 
     #[test]

--- a/tools/rust/automation-cli/src/commands/review/respond.rs
+++ b/tools/rust/automation-cli/src/commands/review/respond.rs
@@ -1,6 +1,7 @@
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Result, bail};
 use clap::Args;
@@ -92,7 +93,8 @@ pub fn run(args: RespondArgs) -> Result<()> {
         ));
     }
 
-    let claude_output = run_claude(&prompt)?;
+    let claude_outcome = run_claude_streamed(&prompt, args.iteration)?;
+    let claude_output = claude_outcome.text.clone();
 
     // Step 3: Check for changes
     output::header("Step 3: Checking for changes");
@@ -103,10 +105,32 @@ pub fn run(args: RespondArgs) -> Result<()> {
     let summary = extract_agent_summary(&claude_output);
 
     if !has_changes {
-        // Detect hallucinated fixes: Claude's summary claims "Fixed Issues" but no files
-        // were actually modified. Retry once with a pointed correction prompt.
+        // Definitive hallucination: summary lists Fixed Issues but Claude made
+        // ZERO file-mutating tool calls during the run. Don't bother retrying —
+        // the retry uses the same prompting strategy Claude already ignored,
+        // and prior iterations show it just hallucinates a second time. Post
+        // an explicit warning, attach the stream-json log for post-mortem,
+        // and exit cleanly so the PR isn't blocked.
+        if summary_claims_fixes(&summary) && claude_outcome.edited_files.is_empty() {
+            output::warn(
+                "Agent hallucinated: claimed Fixed Issues with ZERO file-mutating tool calls",
+            );
+            post_hallucination_comment(
+                args.pr_number,
+                args.iteration,
+                &summary,
+                claude_outcome.stream_log_path.as_deref(),
+            )?;
+            report_no_commit();
+            return Ok(());
+        }
+
+        // Soft hallucination: summary claims fixes, no files changed, but
+        // Claude DID make some tool calls (maybe edits that produced no diff,
+        // or edits to files outside the repo). Retry once with a pointed
+        // correction prompt — this still helps when Claude was mid-task.
         if summary_claims_fixes(&summary) {
-            output::warn("Agent summary claims fixed issues but no files were modified — retrying");
+            output::warn("Agent summary claims fixed issues but git diff is empty — retrying once");
 
             let retry_prompt = format!(
                 "Your previous response claimed to fix issues but did NOT actually modify any files.\n\n\
@@ -126,10 +150,10 @@ pub fn run(args: RespondArgs) -> Result<()> {
                  ---AGENT-SUMMARY-END---\n"
             );
 
-            let retry_output = run_claude(&retry_prompt)?;
+            let retry_outcome = run_claude_streamed(&retry_prompt, args.iteration)?;
             process::run("git", &["add", "-A"])?;
             let retry_has_changes = !process::run_check("git", &["diff", "--cached", "--quiet"])?;
-            let retry_summary = extract_agent_summary(&retry_output);
+            let retry_summary = extract_agent_summary(&retry_outcome.text);
 
             if retry_has_changes {
                 output::info("Retry produced actual file changes");
@@ -144,14 +168,23 @@ pub fn run(args: RespondArgs) -> Result<()> {
                 );
             }
 
-            // Still no changes after retry — post with explicit warning
+            // Still no changes after retry — post with explicit warning,
+            // attaching whichever stream log is more informative.
             let warning_summary = if retry_summary.is_empty() {
                 summary.clone()
             } else {
                 retry_summary
             };
             output::warn("Retry still produced no file changes");
-            post_decision_comment(args.pr_number, args.iteration, false, "", &warning_summary)?;
+            post_hallucination_comment(
+                args.pr_number,
+                args.iteration,
+                &warning_summary,
+                retry_outcome
+                    .stream_log_path
+                    .as_deref()
+                    .or(claude_outcome.stream_log_path.as_deref()),
+            )?;
             report_no_commit();
             return Ok(());
         }
@@ -598,29 +631,162 @@ fn load_claude_md(max_chars: usize) -> String {
     }
 }
 
-fn run_claude(prompt: &str) -> Result<String> {
+/// Tool names that mutate files on disk. If Claude claims to have fixed
+/// issues but called none of these, the claim is a hallucination.
+const FILE_MUTATING_TOOLS: &[&str] = &["Edit", "Write", "MultiEdit", "NotebookEdit"];
+
+/// Result of a Claude invocation: extracted text plus the set of files that
+/// Claude actually mutated via tool_use events, plus the on-disk path of the
+/// raw stream-json log (for artifact upload / post-mortem).
+struct ClaudeOutcome {
+    text: String,
+    edited_files: HashSet<String>,
+    stream_log_path: Option<String>,
+}
+
+/// Invoke Claude in non-interactive print mode with stream-json output, save
+/// the raw stream as a JSONL log file, and parse it into a ClaudeOutcome.
+///
+/// stream-json gives us structured `tool_use` events that we can cross-check
+/// against Claude's free-text summary — without this, we cannot tell whether
+/// Claude actually edited files or just generated a plausible-sounding summary.
+fn run_claude_streamed(prompt: &str, iteration: u32) -> Result<ClaudeOutcome> {
     let claude_cmd = if process::command_exists("claude") {
         "claude"
     } else if process::command_exists("claude-code") {
         "claude-code"
     } else {
         output::warn("Claude CLI not found, skipping AI-assisted fixes");
-        return Ok(String::new());
+        return Ok(ClaudeOutcome {
+            text: String::new(),
+            edited_files: HashSet::new(),
+            stream_log_path: None,
+        });
     };
 
-    output::step("Running Claude with tool access (20 min timeout)...");
+    output::step("Running Claude (-p stream-json, 20 min timeout)...");
     let prompt_file = write_temp_file(prompt)?;
     let prompt_path = Path::new(&prompt_file);
 
-    let result = process::run_capture_with_timeout(
+    let raw = process::run_capture_with_timeout(
         claude_cmd,
-        &["--dangerously-skip-permissions"],
+        &[
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--dangerously-skip-permissions",
+        ],
         prompt_path,
         Duration::from_secs(20 * 60),
     );
 
     let _ = std::fs::remove_file(&prompt_file);
-    result
+    let raw = raw?;
+
+    let (text, edited_files) = parse_claude_stream(&raw);
+    let stream_log_path = save_claude_stream_log(iteration, &raw).ok();
+
+    if let Some(ref p) = stream_log_path {
+        output::info(&format!("Claude stream log saved: {p}"));
+    }
+    output::info(&format!(
+        "Claude tool_use touched {} file(s){}",
+        edited_files.len(),
+        if edited_files.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " ({})",
+                edited_files.iter().cloned().collect::<Vec<_>>().join(", ")
+            )
+        }
+    ));
+
+    Ok(ClaudeOutcome {
+        text,
+        edited_files,
+        stream_log_path,
+    })
+}
+
+/// Parse stream-json output from Claude CLI. Returns concatenated assistant
+/// text plus the set of file paths touched by mutating tool calls.
+///
+/// Claude Code emits one JSON object per line. Assistant messages carry an
+/// inner `message.content` array of blocks; we walk those for `text` and
+/// `tool_use` blocks. Malformed lines are skipped silently — the CLI sometimes
+/// emits non-JSON warnings on stderr and we want to be robust.
+fn parse_claude_stream(stream: &str) -> (String, HashSet<String>) {
+    let mut text = String::new();
+    let mut edited: HashSet<String> = HashSet::new();
+
+    for line in stream.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+
+        match event["type"].as_str() {
+            Some("assistant") => {
+                if let Some(blocks) = event["message"]["content"].as_array() {
+                    for block in blocks {
+                        match block["type"].as_str() {
+                            Some("text") => {
+                                if let Some(t) = block["text"].as_str() {
+                                    text.push_str(t);
+                                    text.push('\n');
+                                }
+                            },
+                            Some("tool_use") => {
+                                let name = block["name"].as_str().unwrap_or("");
+                                if FILE_MUTATING_TOOLS.contains(&name)
+                                    && let Some(path) = block["input"]["file_path"].as_str()
+                                {
+                                    edited.insert(path.to_string());
+                                }
+                            },
+                            _ => {},
+                        }
+                    }
+                }
+            },
+            // Some CLI versions emit a final {"type":"result","result":"..."}
+            // event with the model's last response. Include it so the summary
+            // marker extraction still works if the assistant text was empty.
+            Some("result") => {
+                if let Some(r) = event["result"].as_str() {
+                    text.push_str(r);
+                    text.push('\n');
+                }
+            },
+            _ => {},
+        }
+    }
+
+    (text, edited)
+}
+
+/// Save the raw Claude stream-json output to a JSONL file under
+/// `$RUNNER_TEMP/review-agent-logs/`. The pr-review-fix workflow uploads this
+/// directory as the `review-agent-claude-logs` artifact.
+fn save_claude_stream_log(iteration: u32, content: &str) -> Result<String> {
+    let base = std::env::var("RUNNER_TEMP")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    let dir = base.join("review-agent-logs");
+    std::fs::create_dir_all(&dir)?;
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let path = dir.join(format!("claude-stream-iter{iteration}-{ts}.jsonl"));
+    std::fs::write(&path, content)?;
+    Ok(path.to_string_lossy().to_string())
 }
 
 fn extract_agent_summary(output: &str) -> String {
@@ -739,6 +905,38 @@ fn post_decision_comment(
              *The agent reviewed feedback but determined no code changes were required.*"
         )
     };
+    post_comment(pr_number, &body)
+}
+
+/// Post the explicit hallucination warning comment with a pointer to the
+/// stream-json log artifact for post-mortem.
+fn post_hallucination_comment(
+    pr_number: u64,
+    iteration: u32,
+    summary: &str,
+    stream_log_path: Option<&str>,
+) -> Result<()> {
+    let display_iter = iteration + 1;
+    let log_note = stream_log_path
+        .map(|p| {
+            format!(
+                "\n\n**Stream log:** `{p}`  \n\
+                 _Uploaded as the `review-agent-claude-logs` workflow artifact._"
+            )
+        })
+        .unwrap_or_default();
+
+    let body = format!(
+        "## Review Response Agent (Iteration {display_iter})\n\
+         <!-- agent-metadata:type=review-fix-hallucination:iteration={display_iter} -->\n\n\
+         **Status:** Hallucination detected — no commit\n\n\
+         > **Detection:** The agent's summary below claims to have applied fixes, \
+         > but Claude made **zero** file-mutating tool calls (`Edit` / `Write` / `MultiEdit`) \
+         > during the run. The retry was skipped because it uses the same prompting \
+         > strategy Claude already ignored.{log_note}\n\n\
+         {summary}\n\n---\n\
+         *No file modifications were performed; this iteration produced no commit.*"
+    );
     post_comment(pr_number, &body)
 }
 
@@ -868,6 +1066,62 @@ mod tests {
         assert!(summary.contains("### Fixed Issues"));
         assert!(summary.contains("- a bug"));
         assert!(!summary.contains("preamble"));
+    }
+
+    #[test]
+    fn parse_claude_stream_extracts_text_and_edits() {
+        let stream = r#"{"type":"system","subtype":"init","session_id":"abc"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Reading the file."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"src/foo.rs","old_string":"a","new_string":"b"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"Write","input":{"file_path":"src/bar.rs","content":"hi"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t3","name":"MultiEdit","input":{"file_path":"src/baz.rs","edits":[]}}]}}
+{"type":"result","result":"---AGENT-SUMMARY-START---\n### Fixed Issues\n- foo\n---AGENT-SUMMARY-END---"}
+"#;
+        let (text, edited) = parse_claude_stream(stream);
+        assert!(text.contains("Reading the file."));
+        assert!(text.contains("---AGENT-SUMMARY-START---"));
+        assert_eq!(edited.len(), 3);
+        assert!(edited.contains("src/foo.rs"));
+        assert!(edited.contains("src/bar.rs"));
+        assert!(edited.contains("src/baz.rs"));
+    }
+
+    #[test]
+    fn parse_claude_stream_ignores_non_mutating_tools() {
+        let stream = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"r1","name":"Read","input":{"file_path":"src/foo.rs"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"b1","name":"Bash","input":{"command":"ls"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"g1","name":"Grep","input":{"pattern":"x"}}]}}
+"#;
+        let (_, edited) = parse_claude_stream(stream);
+        assert!(
+            edited.is_empty(),
+            "Read/Bash/Grep should not count as mutations: {edited:?}"
+        );
+    }
+
+    #[test]
+    fn parse_claude_stream_skips_malformed_lines() {
+        let stream = "{not json\n\n{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\ngarbage trailer\n";
+        let (text, edited) = parse_claude_stream(stream);
+        assert!(text.contains("ok"));
+        assert!(edited.is_empty());
+    }
+
+    #[test]
+    fn parse_claude_stream_handles_empty_input() {
+        let (text, edited) = parse_claude_stream("");
+        assert!(text.is_empty());
+        assert!(edited.is_empty());
+    }
+
+    #[test]
+    fn parse_claude_stream_dedupes_repeated_edits() {
+        let stream = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"a.rs"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"a.rs"}}]}}
+"#;
+        let (_, edited) = parse_claude_stream(stream);
+        assert_eq!(edited.len(), 1);
+        assert!(edited.contains("a.rs"));
     }
 
     #[test]

--- a/tools/rust/github-agents-cli/src/review/agents/openrouter.rs
+++ b/tools/rust/github-agents-cli/src/review/agents/openrouter.rs
@@ -9,7 +9,7 @@ use super::ReviewAgent;
 use crate::error::{Error, Result};
 
 /// Default model for OpenRouter reviews
-const DEFAULT_MODEL: &str = "qwen/qwen3.6-plus:free";
+const DEFAULT_MODEL: &str = "qwen/qwen3.6-plus";
 
 /// OpenRouter API endpoint
 const OPENROUTER_API_URL: &str = "https://openrouter.ai/api/v1/chat/completions";


### PR DESCRIPTION
## Summary

This PR addresses three distinct reliability + safety problems in the PR review-response agent.

### 1. Silent push failures (the original problem)

The agent sometimes claimed to fix issues, created a commit locally, and reported success — but `git push` exited 0 without the ref ever reaching the remote, so the work was lost on the next iteration. Fixed by replacing the bare retrying push with `push_and_verify`, which uses `git ls-remote refs/heads/<branch>` to confirm the remote ref actually matches local HEAD, rebases on non-fast-forward (recomputing the expected SHA), and retries up to 5 times. On terminal failure the commit is saved as a `format-patch` and uploaded as the `unpushed-review-commit-<pr>-<run>` workflow artifact (14-day retention).

### 2. Claude hallucinating fixes (discovered during this PR's own review cycle)

Iteration 4 of this PR's review loop exposed a deeper issue: Claude ran for **32 seconds** (impossibly fast), claimed to have added a `Drop` guard refactor, run `cargo check`, and "13 tests pass" — but `git diff` was empty. The retry hallucinated the same way. We had no way to tell because the Claude invocation captured stdout as plain text and only pattern-matched the `---AGENT-SUMMARY-START---` block.

Fixed by switching to `claude -p --output-format stream-json --verbose`, parsing the JSONL stream for `tool_use` events, and collecting the set of files actually mutated by `Edit` / `Write` / `MultiEdit` / `NotebookEdit` calls. When the summary claims `Fixed Issues` but the edited-files set is empty, that's a definitive hallucination — skip the retry (same prompting strategy Claude already ignored), post an explicit warning, and attach the raw stream-json log as a workflow artifact for post-mortem.

### 3. Artifact secret leakage (the hardest one)

Adding the patch + stream-json artifacts in #1 and #2 introduced a new exposure: `actions/upload-artifact@v4` bypasses the `gh-validator` wrapper entirely, so artifacts went to GitHub Actions storage **with no masking**, despite `.secrets.yaml` existing in the repo. Concrete risk: `configure_git()` embeds `AGENT_TOKEN` into `.git/config` via the remote URL, and any `Read .git/config` / `Bash printenv` / `Bash gh auth status` invocation by Claude would land that token in `tool_result` events that we then uploaded.

Fixed with two-pass sanitization on the stream log before write:

1. **Structural redaction (`redact_tool_payloads`)** — walks each JSONL event, strips `Edit`/`Write`/`MultiEdit` content fields and `tool_result` content bodies, replaces them with `<redacted: N chars>` markers. Preserves tool name, file_path, Bash command, and assistant text (so the summary marker still parses) so we can still see *what* Claude was trying to do without seeing the actual payloads.
2. **Pattern masking via `gh-validator::SecretMasker`** — loaded from the same `.secrets.yaml` the `gh` CLI wrapper uses. Catches anything the structural pass missed (tokens in Bash command strings, secrets pasted into PR comments that ended up in Claude's prompt, etc.).

The unpushed-commit patch is masked through `SecretMasker` only — no structural redaction, since the patch *is* the work to recover and stripping its diff bodies would make it un-applicable. **Fail-closed on both:** if `.secrets.yaml` is missing or unparseable, no artifact is written. Better to lose the diagnostic than leak a token.

### 4. Three-state output reporting

Every exit path now sets `made_changes`, `pushed`, and `commit_sha` GitHub Actions outputs via a shared `report_no_commit()` helper, so downstream steps can unambiguously distinguish: pushed-and-verified / committed-but-push-failed / no-commit-this-iteration / hallucination-detected. A job-summary step renders the state clearly.

## Files changed

- `tools/rust/automation-cli/src/commands/review/respond.rs` — `push_and_verify`, `verify_remote_head`, `parse_ls_remote_sha`, `looks_like_non_fast_forward`, `rebase_onto_remote`, `report_no_commit`, `ClaudeOutcome`, `run_claude_streamed`, `parse_claude_stream`, `save_claude_stream_log`, `save_commit_patch`, `redact_tool_payloads`, `redact_event_in_place`, `redact_tool_use_input`, `redact_tool_result`, `redacted_marker`, `load_secret_masker`, `post_hallucination_comment`. 29 unit tests, all green.
- `tools/rust/automation-cli/Cargo.toml` + `Cargo.lock` — `gh-validator` added as a path dep so we share the masker logic instead of duplicating it.
- `.github/actions/pr-review-fix/action.yml` — new `pushed` and `commit_sha` outputs, two new artifact uploads (`unpushed-review-commit-*` on push failure, `review-agent-claude-logs-*` always), and a job-summary step.

## Test plan

- [x] `cargo build --release -p automation-cli`
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`
- [x] `cargo test` — 29 passed, including:
  - 5 tests for `parse_claude_stream` (text+edits, non-mutating tool exclusion, malformed lines, empty input, dedup)
  - 9 tests for `redact_tool_payloads` (Edit/Write/MultiEdit redaction, tool_result string + array forms, Bash command preservation, summary marker preservation, non-JSON passthrough, size marker)
  - 5 tests for `parse_ls_remote_sha` and `looks_like_non_fast_forward`
- [x] Manual smoke test of `claude -p --output-format stream-json --verbose --dangerously-skip-permissions` on the runner — flags accepted, output format matches the parser
- [x] Live confirmation that the masker works on PR comments: posting a comment with a `https://x-access-token:{token}@github.com/...` example triggered the wrapper's `[gh-validator] Masked pattern: URL_WITH_AUTH` line (the same masker now wired into artifact paths)
- [x] Release binary installed at `~/.cargo/bin/automation-cli` (2.88 MB, gh-validator brings in ureq + rustls)
- [x] Live evidence: iterations 1–3 of this PR's own review cycle successfully created commits AND pushed them, exercising `push_and_verify`
- [ ] Live evidence: a future hallucinating iteration should now post the new "Hallucination detected" comment, upload a *sanitized* stream-json log artifact, and skip the retry
