### PR TITLE
feat: add review precommit checks and finetune review agent criteria

### DIFF
--- a/.github/actions/pr-review-fix/action.yml
+++ b/.github/actions/pr-review-fix/action.yml
@@ -1,5 +1,5 @@
 name: 'PR Review Fix'
-description: 'Apply fixes based on AI review feedback from Claude, OpenRouter, Gemini, and Codex reviews'
+description: 'Apply fixes based on AI review feedback with precommit checks (autoformat + lint) before and after agent changes'
 
 inputs:
   pr_number:

--- a/docs/guides/agent-council-setup-guide.md
+++ b/docs/guides/agent-council-setup-guide.md
@@ -46,11 +46,15 @@ PR opened/updated
     |         uses OpenRouter HTTP API          |
     |                                           v
     +---> [agent-review-response job]   --> automation-cli review respond <PR> <BRANCH> <ITER> <MAX>
-    |         uses Claude Code CLI to fix       |
+    |         precommit autoformat+lint         |
+    |         + Claude Code CLI to fix          |
     |         issues found by reviewers         v
     +---> [agent-failure-handler job]   --> automation-cli review failure <PR> <BRANCH> <ITER> <MAX> "format,lint,test"
-              uses Claude Code CLI to fix
-              CI failures automatically
+    |         uses Claude Code CLI to fix       |
+    |         CI failures automatically         v
+    +---> (standalone)                  --> automation-cli review precommit --autoformat --lint --test
+              flexible precommit checks
+              for custom agent workflows
 ```
 
 Reviews are **advisory** (non-blocking). CI is **blocking**. The auto-fix agent commits directly to the PR branch.
@@ -1114,11 +1118,20 @@ runs:
    - Downloads all review artifacts from the parallel review jobs
    - Checks iteration count (max 5, extensible via `[CONTINUE]` admin comments)
    - Calls `automation-cli review respond <PR> <BRANCH> <ITER> <MAX>`
-   - This invokes Claude Code with `--dangerously-skip-permissions` to read the reviews, understand the issues, fix the code, and commit+push
+   - Runs precommit autoformat before invoking Claude (formats + restages changed files)
+   - Invokes Claude Code with `--dangerously-skip-permissions` to read the reviews, understand the issues, and fix the code
+   - After Claude's changes, runs precommit checks (autoformat + lint). If lint fails, feeds errors back to Claude for a targeted fix pass
+   - Commits and pushes the result
 2. If CI **fails**, `agent-failure-handler` runs instead:
    - Calls `automation-cli review failure <PR> <BRANCH> <ITER> <MAX> "format,lint,test"`
    - Claude reads the CI logs, fixes the issues, commits+pushes
-3. The push triggers a new workflow run, creating a feedback loop until:
+3. Standalone precommit checks are also available for custom workflows:
+   - `automation-cli review precommit --autoformat` -- format + restage
+   - `automation-cli review precommit --lint` -- run lint checks, report failures
+   - `automation-cli review precommit --test` -- run tests, report failures
+   - `automation-cli review precommit --stage <stages>` -- run arbitrary CI stages
+   - Combine flags freely: `--autoformat --lint --test --fail-on-error`
+4. The push triggers a new workflow run, creating a feedback loop until:
    - Everything passes, or
    - The iteration limit is reached (default 5)
 
@@ -1128,6 +1141,8 @@ runs:
 |-----------|---------|
 | Fork guard | Blocks fork PRs from self-hosted runners |
 | Iteration limit | Max 5 auto-fix attempts per agent type per PR |
+| Severity taper | Iteration 3: medium-severity only; iteration 4+: critical-only |
+| Precommit checks | Autoformat + lint run before and after agent changes |
 | `[CONTINUE]` comments | Admins can extend the limit |
 | `no-auto-fix` label | Disables auto-fix entirely for a PR |
 | `AGENT_TOKEN` | Separate PAT scoped to only what the fix agent needs |

--- a/tools/rust/automation-cli/src/commands/review/failure.rs
+++ b/tools/rust/automation-cli/src/commands/review/failure.rs
@@ -120,9 +120,9 @@ pub fn run(args: FailureArgs) -> Result<()> {
 
     // Step 1: Autoformat + restage
     output::header("Step 1: Running autoformat");
-    let _ = process::run("./automation/ci-cd/run-ci.sh", &["autoformat"]);
-    // Restage so format changes are included in the diff
-    process::run("git", &["add", "-A"])?;
+    if let Err(e) = super::precommit::run_autoformat_and_restage() {
+        output::warn(&format!("Autoformat/restage failed (non-fatal): {e}"));
+    }
 
     // Step 2: Capture remaining lint errors
     output::header("Step 2: Checking for remaining lint issues");
@@ -176,7 +176,7 @@ pub fn run(args: FailureArgs) -> Result<()> {
 
     // Step 4: Commit
     output::header("Step 4: Checking for changes");
-    process::run("git", &["add", "-A"])?;
+    process::run("git", &["add", "-u"])?;
 
     if process::run_check("git", &["diff", "--cached", "--quiet"])? {
         output::info("No changes to commit");

--- a/tools/rust/automation-cli/src/commands/review/failure.rs
+++ b/tools/rust/automation-cli/src/commands/review/failure.rs
@@ -118,9 +118,10 @@ pub fn run(args: FailureArgs) -> Result<()> {
         if has_test_failure { "test-suite" } else { "" }
     ));
 
-    // Step 1: Autoformat
+    // Step 1: Autoformat + restage
     output::header("Step 1: Running autoformat");
     let _ = process::run("./automation/ci-cd/run-ci.sh", &["autoformat"]);
+    // Restage so format changes are included in the diff
     process::run("git", &["add", "-A"])?;
 
     // Step 2: Capture remaining lint errors

--- a/tools/rust/automation-cli/src/commands/review/mod.rs
+++ b/tools/rust/automation-cli/src/commands/review/mod.rs
@@ -1,4 +1,5 @@
 mod failure;
+mod precommit;
 mod respond;
 mod trust;
 
@@ -7,15 +8,18 @@ use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum ReviewAction {
-    /// Respond to AI code review feedback (Gemini/Codex) using Claude
+    /// Respond to AI code review feedback using Claude
     Respond(respond::RespondArgs),
     /// Handle CI pipeline failures with automated fixes
     Failure(failure::FailureArgs),
+    /// Run precommit checks (autoformat, lint, test) before committing agent changes
+    Precommit(precommit::PrecommitArgs),
 }
 
 pub fn run(action: ReviewAction) -> Result<()> {
     match action {
         ReviewAction::Respond(args) => respond::run(args),
         ReviewAction::Failure(args) => failure::run(args),
+        ReviewAction::Precommit(args) => precommit::run(args),
     }
 }

--- a/tools/rust/automation-cli/src/commands/review/precommit.rs
+++ b/tools/rust/automation-cli/src/commands/review/precommit.rs
@@ -186,7 +186,7 @@ pub fn run(args: PrecommitArgs) -> Result<()> {
 
 /// Run autoformat via the CI stage, then restage any files that were modified.
 /// Returns the number of files restaged.
-fn run_autoformat_and_restage() -> Result<u32> {
+pub(super) fn run_autoformat_and_restage() -> Result<u32> {
     // Capture the set of currently-staged files before formatting
     let staged_before = get_staged_files()?;
 
@@ -246,7 +246,7 @@ fn run_ci_stage(stage: &str) -> bool {
 
 /// Run a CI stage and capture its output for error reporting.
 /// Returns a CheckResult with the stage name, pass/fail, and filtered error lines.
-fn run_ci_stage_captured(stage: &str) -> Result<CheckResult> {
+pub(super) fn run_ci_stage_captured(stage: &str) -> Result<CheckResult> {
     let raw = Command::new("./automation/ci-cd/run-ci.sh")
         .arg(stage)
         .stdin(Stdio::null())

--- a/tools/rust/automation-cli/src/commands/review/precommit.rs
+++ b/tools/rust/automation-cli/src/commands/review/precommit.rs
@@ -91,6 +91,8 @@ pub fn run(args: PrecommitArgs) -> Result<()> {
     // Validate that at least one check was requested
     if !args.autoformat && args.lint.is_none() && args.test.is_none() && args.stage.is_none() {
         output::warn("No checks requested (use --autoformat, --lint, --test, or --stage)");
+        project::set_github_output("precommit_passed", "true");
+        project::set_github_output("precommit_autoformat_changed", "0");
         return Ok(());
     }
 
@@ -190,6 +192,16 @@ pub(super) fn run_autoformat_and_restage() -> Result<u32> {
     // Capture the set of currently-staged files before formatting
     let staged_before = get_staged_files()?;
 
+    // Snapshot unstaged tracked files before formatting so we can isolate
+    // formatter-modified files from pre-existing edits afterwards
+    let before_output = process::run_capture("git", &["diff", "--name-only"])?;
+    let unstaged_before: std::collections::HashSet<String> = before_output
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(String::from)
+        .collect();
+
     // Run the autoformat CI stage (ruff format, cargo fmt, etc.)
     let _ = run_ci_stage("autoformat");
 
@@ -207,21 +219,27 @@ pub(super) fn run_autoformat_and_restage() -> Result<u32> {
         restaged = staged_before.len() as u32;
     }
 
-    // Also stage any new untracked changes from autoformat (files that weren't
-    // staged before but were modified by the formatter)
-    let diff_output = process::run_capture("git", &["diff", "--name-only"])?;
-    let unstaged_modified: Vec<&str> = diff_output
+    // Stage tracked files that were modified by the formatter (not previously
+    // unstaged). We compare the unstaged set before/after to isolate changes
+    // the formatter actually made, avoiding sweeping in pre-existing edits.
+    let after_output = process::run_capture("git", &["diff", "--name-only"])?;
+    let unstaged_after: std::collections::HashSet<String> = after_output
         .lines()
         .map(str::trim)
         .filter(|l| !l.is_empty())
+        .map(String::from)
         .collect();
-    if !unstaged_modified.is_empty() {
-        for chunk in unstaged_modified.chunks(100) {
+    let formatter_modified: Vec<&str> = unstaged_after
+        .difference(&unstaged_before)
+        .map(|s| s.as_str())
+        .collect();
+    if !formatter_modified.is_empty() {
+        for chunk in formatter_modified.chunks(100) {
             let mut args = vec!["add", "--"];
             args.extend_from_slice(chunk);
             process::run("git", &args)?;
         }
-        restaged += unstaged_modified.len() as u32;
+        restaged += formatter_modified.len() as u32;
     }
 
     Ok(restaged)

--- a/tools/rust/automation-cli/src/commands/review/precommit.rs
+++ b/tools/rust/automation-cli/src/commands/review/precommit.rs
@@ -181,6 +181,8 @@ pub fn run(args: PrecommitArgs) -> Result<()> {
         if args.fail_on_error {
             bail!("precommit checks failed: {}", failed_names.join(", "));
         }
+    } else {
+        project::set_github_output("precommit_failed_checks", "");
     }
 
     Ok(())

--- a/tools/rust/automation-cli/src/commands/review/precommit.rs
+++ b/tools/rust/automation-cli/src/commands/review/precommit.rs
@@ -1,0 +1,408 @@
+use std::process::{Command, Stdio};
+
+use anyhow::{Result, bail};
+use clap::Args;
+
+use crate::shared::{output, process, project};
+
+/// Maximum lines of error output to capture per check.
+const MAX_ERROR_LINES: usize = 200;
+
+#[derive(Args)]
+pub struct PrecommitArgs {
+    /// Run autoformat and restage changed files
+    #[arg(long)]
+    pub autoformat: bool,
+
+    /// Run lint checks and report failures.
+    /// Accepts an optional comma-separated list of CI stages to run
+    /// (e.g., "lint-basic,lint-full"). Defaults to "lint-basic" if no value given.
+    #[arg(long, num_args = 0..=1, default_missing_value = "lint-basic")]
+    pub lint: Option<String>,
+
+    /// Run test suite and report failures.
+    /// Accepts an optional comma-separated list of CI stages to run
+    /// (e.g., "test,econ-test"). Defaults to "test" if no value given.
+    #[arg(long, num_args = 0..=1, default_missing_value = "test")]
+    pub test: Option<String>,
+
+    /// Run arbitrary CI stages (comma-separated).
+    /// Output is captured and printed; non-zero exit from any stage is reported.
+    #[arg(long)]
+    pub stage: Option<String>,
+
+    /// Exit non-zero if any check fails (default: report only).
+    /// When false, failures are printed but the command exits 0
+    /// so callers can decide how to handle them.
+    #[arg(long, default_value = "false")]
+    pub fail_on_error: bool,
+}
+
+/// Result of a single precommit check.
+pub struct CheckResult {
+    pub name: String,
+    pub passed: bool,
+    pub error_output: String,
+}
+
+/// Aggregated result of all precommit checks.
+pub struct PrecommitResult {
+    pub checks: Vec<CheckResult>,
+    pub autoformat_changed_files: u32,
+}
+
+impl PrecommitResult {
+    pub fn all_passed(&self) -> bool {
+        self.checks.iter().all(|c| c.passed)
+    }
+
+    /// Build a machine-readable summary suitable for feeding back to an agent.
+    pub fn summary(&self) -> String {
+        let mut out = String::new();
+
+        if self.autoformat_changed_files > 0 {
+            out.push_str(&format!(
+                "Autoformat: restaged {} file(s)\n",
+                self.autoformat_changed_files
+            ));
+        }
+
+        for check in &self.checks {
+            let status = if check.passed { "PASS" } else { "FAIL" };
+            out.push_str(&format!("[{status}] {}\n", check.name));
+            if !check.passed && !check.error_output.is_empty() {
+                out.push_str(&check.error_output);
+                if !check.error_output.ends_with('\n') {
+                    out.push('\n');
+                }
+            }
+        }
+
+        out
+    }
+}
+
+pub fn run(args: PrecommitArgs) -> Result<()> {
+    let root = project::find_project_root()?;
+    std::env::set_current_dir(&root)?;
+
+    output::header("Review Precommit Checks");
+
+    // Validate that at least one check was requested
+    if !args.autoformat && args.lint.is_none() && args.test.is_none() && args.stage.is_none() {
+        output::warn("No checks requested (use --autoformat, --lint, --test, or --stage)");
+        return Ok(());
+    }
+
+    let mut result = PrecommitResult {
+        checks: Vec::new(),
+        autoformat_changed_files: 0,
+    };
+
+    // --- Autoformat + restage ---
+    if args.autoformat {
+        output::step("Running autoformat...");
+        let changed = run_autoformat_and_restage()?;
+        result.autoformat_changed_files = changed;
+        if changed > 0 {
+            output::success(&format!("Autoformat: restaged {changed} file(s)"));
+        } else {
+            output::info("Autoformat: no changes");
+        }
+    }
+
+    // --- Lint checks ---
+    if let Some(ref stages) = args.lint {
+        for stage_name in stages.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            output::step(&format!("Running lint check: {stage_name}..."));
+            let check = run_ci_stage_captured(stage_name)?;
+            if check.passed {
+                output::success(&format!("{stage_name}: passed"));
+            } else {
+                output::fail(&format!("{stage_name}: failed"));
+            }
+            result.checks.push(check);
+        }
+    }
+
+    // --- Test checks ---
+    if let Some(ref stages) = args.test {
+        for stage_name in stages.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            output::step(&format!("Running test check: {stage_name}..."));
+            let check = run_ci_stage_captured(stage_name)?;
+            if check.passed {
+                output::success(&format!("{stage_name}: passed"));
+            } else {
+                output::fail(&format!("{stage_name}: failed"));
+            }
+            result.checks.push(check);
+        }
+    }
+
+    // --- Arbitrary stages ---
+    if let Some(ref stages) = args.stage {
+        for stage_name in stages.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            output::step(&format!("Running stage: {stage_name}..."));
+            let check = run_ci_stage_captured(stage_name)?;
+            if check.passed {
+                output::success(&format!("{stage_name}: passed"));
+            } else {
+                output::fail(&format!("{stage_name}: failed"));
+            }
+            result.checks.push(check);
+        }
+    }
+
+    // --- Summary ---
+    output::header("Precommit Summary");
+    let summary = result.summary();
+    // Print summary to stdout so callers/agents can parse it
+    print!("{summary}");
+
+    // Set GitHub outputs for workflow integration
+    let has_failures = !result.all_passed();
+    project::set_github_output("precommit_passed", &(!has_failures).to_string());
+    project::set_github_output(
+        "precommit_autoformat_changed",
+        &result.autoformat_changed_files.to_string(),
+    );
+
+    if has_failures {
+        let failed_names: Vec<&str> = result
+            .checks
+            .iter()
+            .filter(|c| !c.passed)
+            .map(|c| c.name.as_str())
+            .collect();
+        project::set_github_output("precommit_failed_checks", &failed_names.join(","));
+
+        if args.fail_on_error {
+            bail!("precommit checks failed: {}", failed_names.join(", "));
+        }
+    }
+
+    Ok(())
+}
+
+/// Run autoformat via the CI stage, then restage any files that were modified.
+/// Returns the number of files restaged.
+fn run_autoformat_and_restage() -> Result<u32> {
+    // Capture the set of currently-staged files before formatting
+    let staged_before = get_staged_files()?;
+
+    // Run the autoformat CI stage (ruff format, cargo fmt, etc.)
+    let _ = run_ci_stage("autoformat");
+
+    // Restage files that were already staged (autoformat may have modified them)
+    let mut restaged = 0u32;
+    if !staged_before.is_empty() {
+        // Add back all previously-staged files so format changes are included
+        let files: Vec<&str> = staged_before.iter().map(|s| s.as_str()).collect();
+        // Stage in batches to avoid argument-list-too-long
+        for chunk in files.chunks(100) {
+            let mut args = vec!["add", "--"];
+            args.extend_from_slice(chunk);
+            process::run("git", &args)?;
+        }
+        restaged = staged_before.len() as u32;
+    }
+
+    // Also stage any new untracked changes from autoformat (files that weren't
+    // staged before but were modified by the formatter)
+    let diff_output = process::run_capture("git", &["diff", "--name-only"])?;
+    let unstaged_modified: Vec<&str> = diff_output
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    if !unstaged_modified.is_empty() {
+        for chunk in unstaged_modified.chunks(100) {
+            let mut args = vec!["add", "--"];
+            args.extend_from_slice(chunk);
+            process::run("git", &args)?;
+        }
+        restaged += unstaged_modified.len() as u32;
+    }
+
+    Ok(restaged)
+}
+
+/// Get the list of currently staged file paths.
+fn get_staged_files() -> Result<Vec<String>> {
+    let output = process::run_capture("git", &["diff", "--cached", "--name-only"])?;
+    Ok(output
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(String::from)
+        .collect())
+}
+
+/// Run a CI stage via automation-cli (or the legacy shell wrapper) and return
+/// success/failure status without aborting the process.
+fn run_ci_stage(stage: &str) -> bool {
+    process::run("./automation/ci-cd/run-ci.sh", &[stage]).is_ok()
+}
+
+/// Run a CI stage and capture its output for error reporting.
+/// Returns a CheckResult with the stage name, pass/fail, and filtered error lines.
+fn run_ci_stage_captured(stage: &str) -> Result<CheckResult> {
+    let raw = Command::new("./automation/ci-cd/run-ci.sh")
+        .arg(stage)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output();
+
+    match raw {
+        Ok(output) => {
+            let passed = output.status.success();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            // Extract error-relevant lines for agent consumption
+            let error_output = if passed {
+                String::new()
+            } else {
+                extract_error_lines(&stdout, &stderr)
+            };
+
+            Ok(CheckResult {
+                name: stage.to_string(),
+                passed,
+                error_output,
+            })
+        },
+        Err(e) => Ok(CheckResult {
+            name: stage.to_string(),
+            passed: false,
+            error_output: format!("Failed to execute stage: {e}"),
+        }),
+    }
+}
+
+/// Extract the most relevant error lines from combined stdout/stderr output.
+/// Filters for error indicators and truncates to MAX_ERROR_LINES.
+fn extract_error_lines(stdout: &str, stderr: &str) -> String {
+    let combined = format!("{stdout}{stderr}");
+    let error_lines: Vec<&str> = combined
+        .lines()
+        .filter(|l| {
+            let lower = l.to_lowercase();
+            lower.contains("error")
+                || lower.contains("warning")
+                || lower.contains("failed")
+                || lower.contains("found ")
+                || lower.contains("traceback")
+                || lower.contains("assertionerror")
+                || lower.contains("panicked")
+                || lower.contains("cannot find")
+                || lower.contains("undefined")
+                || lower.contains("unused")
+                || lower.contains("mismatched")
+        })
+        .take(MAX_ERROR_LINES)
+        .collect();
+
+    if error_lines.is_empty() {
+        // If no error-specific lines found, return the last N lines as context
+        let all_lines: Vec<&str> = combined.lines().collect();
+        let start = all_lines.len().saturating_sub(MAX_ERROR_LINES);
+        return all_lines[start..].join("\n");
+    }
+
+    error_lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn precommit_result_summary_format() {
+        let result = PrecommitResult {
+            checks: vec![
+                CheckResult {
+                    name: "lint-basic".to_string(),
+                    passed: true,
+                    error_output: String::new(),
+                },
+                CheckResult {
+                    name: "test".to_string(),
+                    passed: false,
+                    error_output: "src/foo.rs:10: error[E0308]: mismatched types".to_string(),
+                },
+            ],
+            autoformat_changed_files: 3,
+        };
+
+        let summary = result.summary();
+        assert!(summary.contains("Autoformat: restaged 3 file(s)"));
+        assert!(summary.contains("[PASS] lint-basic"));
+        assert!(summary.contains("[FAIL] test"));
+        assert!(summary.contains("mismatched types"));
+    }
+
+    #[test]
+    fn precommit_result_all_passed() {
+        let result = PrecommitResult {
+            checks: vec![CheckResult {
+                name: "format".to_string(),
+                passed: true,
+                error_output: String::new(),
+            }],
+            autoformat_changed_files: 0,
+        };
+        assert!(result.all_passed());
+    }
+
+    #[test]
+    fn precommit_result_has_failure() {
+        let result = PrecommitResult {
+            checks: vec![
+                CheckResult {
+                    name: "format".to_string(),
+                    passed: true,
+                    error_output: String::new(),
+                },
+                CheckResult {
+                    name: "lint-full".to_string(),
+                    passed: false,
+                    error_output: "error: unused import".to_string(),
+                },
+            ],
+            autoformat_changed_files: 0,
+        };
+        assert!(!result.all_passed());
+    }
+
+    #[test]
+    fn extract_error_lines_filters_correctly() {
+        let stdout = "Building...\nOK\nsrc/foo.rs:10: error[E0308]: mismatched types\nFinished\n";
+        let stderr = "warning: unused variable `x`\n";
+        let result = extract_error_lines(stdout, stderr);
+        assert!(result.contains("error[E0308]"));
+        assert!(result.contains("unused variable"));
+        assert!(!result.contains("Building"));
+        assert!(!result.contains("Finished"));
+    }
+
+    #[test]
+    fn extract_error_lines_falls_back_to_tail() {
+        let stdout = "line1\nline2\nline3\n";
+        let stderr = "";
+        let result = extract_error_lines(stdout, stderr);
+        // No error-specific lines, so should return tail
+        assert!(result.contains("line1"));
+    }
+
+    #[test]
+    fn summary_empty_checks() {
+        let result = PrecommitResult {
+            checks: Vec::new(),
+            autoformat_changed_files: 0,
+        };
+        assert!(result.summary().is_empty());
+        assert!(result.all_passed());
+    }
+}

--- a/tools/rust/automation-cli/src/commands/review/precommit.rs
+++ b/tools/rust/automation-cli/src/commands/review/precommit.rs
@@ -93,6 +93,7 @@ pub fn run(args: PrecommitArgs) -> Result<()> {
         output::warn("No checks requested (use --autoformat, --lint, --test, or --stage)");
         project::set_github_output("precommit_passed", "true");
         project::set_github_output("precommit_autoformat_changed", "0");
+        project::set_github_output("precommit_failed_checks", "");
         return Ok(());
     }
 

--- a/tools/rust/automation-cli/src/commands/review/respond.rs
+++ b/tools/rust/automation-cli/src/commands/review/respond.rs
@@ -76,9 +76,9 @@ pub fn run(args: RespondArgs) -> Result<()> {
     truncate_in_place(&mut review_content, MAX_REVIEW_CONTENT_CHARS);
     output::info(&format!("Review content: {} chars", review_content.len()));
 
-    // Step 1: Run autoformat
-    output::header("Step 1: Running autoformat");
-    let _ = process::run("./automation/ci-cd/run-ci.sh", &["autoformat"]);
+    // Step 1: Run precommit autoformat (formats + restages changed files)
+    output::header("Step 1: Running precommit autoformat");
+    run_precommit_autoformat();
 
     // Step 2: Invoke Claude
     output::header("Step 2: Invoking Claude for review feedback");
@@ -97,8 +97,29 @@ pub fn run(args: RespondArgs) -> Result<()> {
     let claude_outcome = run_claude_streamed(&prompt, args.iteration)?;
     let claude_output = claude_outcome.text.clone();
 
-    // Step 3: Check for changes
-    output::header("Step 3: Checking for changes");
+    // Step 3: Run precommit checks (autoformat + lint)
+    output::header("Step 3: Running precommit checks");
+    run_precommit_autoformat();
+
+    // Capture lint failures so we can feed them back to Claude if needed
+    let lint_failures = run_precommit_lint_capture();
+    if !lint_failures.is_empty() {
+        output::warn("Precommit lint check found issues -- invoking Claude to fix");
+        let lint_fix_prompt = format!(
+            "The following lint/format issues were found after your changes. \
+             Please fix them. Make only the minimal changes needed to resolve these errors.\n\n\
+             ## Lint Failures\n\n{lint_failures}\n\n\
+             Fix these issues now using the Edit tool. Do NOT add comments explaining \
+             the fixes -- just apply the minimal correction."
+        );
+        let _ = run_claude_streamed(&lint_fix_prompt, args.iteration);
+
+        // Re-run autoformat + restage after lint fixes
+        run_precommit_autoformat();
+    }
+
+    // Stage everything and check for changes
+    output::header("Step 4: Checking for changes");
     process::run("git", &["add", "-A"])?;
 
     let has_changes = !process::run_check("git", &["diff", "--cached", "--quiet"])?;
@@ -204,7 +225,7 @@ fn commit_and_push(args: &RespondArgs, summary: &str) -> Result<()> {
     let display_iter = args.iteration + 1;
     let commit_msg = format!(
         "fix: address AI review feedback (iteration {})\n\n\
-         Automated fix by Claude in response to Gemini/Codex review.\n\n\
+         Automated fix by Claude in response to AI review feedback.\n\n\
          Iteration: {}/{}\n\n\
          Co-Authored-By: AI Review Agent <noreply@anthropic.com>",
         display_iter, display_iter, args.max_iterations
@@ -234,7 +255,7 @@ fn commit_and_push(args: &RespondArgs, summary: &str) -> Result<()> {
     // Push with verification: git push alone is unreliable (can exit 0 while the
     // remote ref is unchanged). push_and_verify confirms via ls-remote that the
     // commit actually landed, handles non-fast-forward by rebasing, and retries.
-    output::header("Step 4: Pushing changes");
+    output::header("Step 5: Pushing changes");
     let branch = args.branch.clone();
     let initial_sha = commit_full.clone();
     let push_result = temporarily_disable_pre_push_hook(|| push_and_verify(&branch, &initial_sha));
@@ -575,20 +596,31 @@ fn build_prompt(
         args.iteration, args.max_iterations
     );
 
-    if args.iteration >= 3 {
+    if args.iteration >= 4 {
         prompt.push_str(
-            "**IMPORTANT: This PR has already been through multiple review cycles.**\n\
+            "**IMPORTANT: This PR has already been through many review cycles.**\n\
              At this point, only fix issues that meet the HIGH SEVERITY threshold:\n\
              - Security vulnerabilities (injection, auth bypass, data exposure)\n\
              - Crashes or data corruption bugs\n\
              - Build/test failures\n\n\
              Do NOT fix: minor style issues, speculative edge cases, theoretical improvements.\n\n",
         );
+    } else if args.iteration >= 3 {
+        prompt.push_str(
+            "**NOTE: This PR has been through several review cycles.**\n\
+             Focus on issues with clear, demonstrable impact:\n\
+             - Security vulnerabilities and correctness bugs\n\
+             - Build/test failures\n\
+             - Logic errors that produce wrong results\n\
+             - Resource leaks or error-handling gaps at trust boundaries\n\n\
+             Skip: style preferences, speculative edge cases, theoretical improvements \
+             with no concrete failure scenario.\n\n",
+        );
     }
 
     prompt.push_str(
         "## Your Task\n\
-         Review the feedback from Gemini and Codex below, and fix legitimate issues.\n\n\
+         Review the feedback from the AI reviewers below, and fix legitimate issues.\n\n\
          ## How to Work\n\
          1. **Read the files first** - Use the Read tool to examine any file mentioned\n\
          2. **Verify claims** - Check if the reported issue actually exists\n\
@@ -1164,6 +1196,63 @@ fn write_temp_file(content: &str) -> Result<String> {
     let path = std::env::temp_dir().join(format!("automation-cli-{}-{n}", std::process::id()));
     std::fs::write(&path, content)?;
     Ok(path.to_string_lossy().to_string())
+}
+
+/// Run autoformat via the precommit module and restage changed files.
+/// Errors are logged but not fatal -- formatting is best-effort.
+fn run_precommit_autoformat() {
+    let _ = process::run("./automation/ci-cd/run-ci.sh", &["autoformat"]);
+    // Restage everything so format changes are included
+    let _ = process::run("git", &["add", "-A"]);
+}
+
+/// Run lint checks and capture error output for agent feedback.
+/// Returns the error output string (empty if all checks pass).
+fn run_precommit_lint_capture() -> String {
+    use std::process::{Command, Stdio};
+
+    let stages = ["lint-basic"];
+    let mut errors = String::new();
+
+    for stage in &stages {
+        let result = Command::new("./automation/ci-cd/run-ci.sh")
+            .arg(stage)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
+
+        if let Ok(output) = result
+            && !output.status.success()
+        {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let combined = format!("{stdout}{stderr}");
+            let relevant: Vec<&str> = combined
+                .lines()
+                .filter(|l| {
+                    let lower = l.to_lowercase();
+                    lower.contains("error")
+                        || lower.contains("warning")
+                        || lower.contains("failed")
+                        || lower.contains("unused")
+                        || lower.contains("undefined")
+                        || lower.contains("mismatched")
+                })
+                .take(150)
+                .collect();
+            if !relevant.is_empty() {
+                if !errors.is_empty() {
+                    errors.push('\n');
+                }
+                errors.push_str(&format!("### {stage} failures:\n"));
+                errors.push_str(&relevant.join("\n"));
+                errors.push('\n');
+            }
+        }
+    }
+
+    errors
 }
 
 #[cfg(test)]

--- a/tools/rust/automation-cli/src/commands/review/respond.rs
+++ b/tools/rust/automation-cli/src/commands/review/respond.rs
@@ -116,6 +116,14 @@ pub fn run(args: RespondArgs) -> Result<()> {
 
         // Re-run autoformat + restage after lint fixes
         run_precommit_autoformat();
+
+        // Verify lint fixes resolved the issues
+        let remaining = run_precommit_lint_capture();
+        if !remaining.is_empty() {
+            output::warn(
+                "Lint issues remain after fix attempt -- will be caught in next iteration",
+            );
+        }
     }
 
     // Stage modifications to tracked files (avoid staging untracked temp files/artifacts)

--- a/tools/rust/automation-cli/src/commands/review/respond.rs
+++ b/tools/rust/automation-cli/src/commands/review/respond.rs
@@ -118,9 +118,9 @@ pub fn run(args: RespondArgs) -> Result<()> {
         run_precommit_autoformat();
     }
 
-    // Stage everything and check for changes
+    // Stage modifications to tracked files (avoid staging untracked temp files/artifacts)
     output::header("Step 4: Checking for changes");
-    process::run("git", &["add", "-A"])?;
+    process::run("git", &["add", "-u"])?;
 
     let has_changes = !process::run_check("git", &["diff", "--cached", "--quiet"])?;
 
@@ -173,7 +173,7 @@ pub fn run(args: RespondArgs) -> Result<()> {
             );
 
             let retry_outcome = run_claude_streamed(&retry_prompt, args.iteration)?;
-            process::run("git", &["add", "-A"])?;
+            process::run("git", &["add", "-u"])?;
             let retry_has_changes = !process::run_check("git", &["diff", "--cached", "--quiet"])?;
             let retry_summary = extract_agent_summary(&retry_outcome.text);
 
@@ -1201,54 +1201,31 @@ fn write_temp_file(content: &str) -> Result<String> {
 /// Run autoformat via the precommit module and restage changed files.
 /// Errors are logged but not fatal -- formatting is best-effort.
 fn run_precommit_autoformat() {
-    let _ = process::run("./automation/ci-cd/run-ci.sh", &["autoformat"]);
-    // Restage everything so format changes are included
-    let _ = process::run("git", &["add", "-A"]);
+    if let Err(e) = super::precommit::run_autoformat_and_restage() {
+        output::warn(&format!("Autoformat/restage failed (non-fatal): {e}"));
+    }
 }
 
 /// Run lint checks and capture error output for agent feedback.
 /// Returns the error output string (empty if all checks pass).
 fn run_precommit_lint_capture() -> String {
-    use std::process::{Command, Stdio};
-
     let stages = ["lint-basic"];
     let mut errors = String::new();
 
     for stage in &stages {
-        let result = Command::new("./automation/ci-cd/run-ci.sh")
-            .arg(stage)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output();
-
-        if let Ok(output) = result
-            && !output.status.success()
-        {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let combined = format!("{stdout}{stderr}");
-            let relevant: Vec<&str> = combined
-                .lines()
-                .filter(|l| {
-                    let lower = l.to_lowercase();
-                    lower.contains("error")
-                        || lower.contains("warning")
-                        || lower.contains("failed")
-                        || lower.contains("unused")
-                        || lower.contains("undefined")
-                        || lower.contains("mismatched")
-                })
-                .take(150)
-                .collect();
-            if !relevant.is_empty() {
+        match super::precommit::run_ci_stage_captured(stage) {
+            Ok(check) if !check.passed => {
                 if !errors.is_empty() {
                     errors.push('\n');
                 }
                 errors.push_str(&format!("### {stage} failures:\n"));
-                errors.push_str(&relevant.join("\n"));
+                errors.push_str(&check.error_output);
                 errors.push('\n');
-            }
+            },
+            Err(e) => {
+                output::warn(&format!("Failed to run {stage}: {e}"));
+            },
+            _ => {},
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `automation-cli review precommit` subcommand with flexible pre-commit checks (autoformat+restage, lint, test, arbitrary CI stages) for agent workflows
- Integrate precommit into the review respond flow: autoformat before/after Claude, with a lint feedback loop that feeds failures back for targeted fixes
- Finetune iteration severity taper: iteration 3 now allows medium-severity fixes (logic errors, resource leaks); critical-only moves to iteration 4+
- Update prompt language from legacy "Gemini/Codex" to "AI reviewers"
- Update docs and action description

### New CLI usage

```bash
# Autoformat + restage
automation-cli review precommit --autoformat

# Lint (defaults to lint-basic, accepts comma-separated stages)
automation-cli review precommit --lint
automation-cli review precommit --lint lint-basic,lint-full

# Tests
automation-cli review precommit --test

# Arbitrary CI stages
automation-cli review precommit --stage format,ruff

# Combine freely
automation-cli review precommit --autoformat --lint --test --fail-on-error
```

### Review criteria changes

| Iteration | Before | After |
|-----------|--------|-------|
| 1-2 | No restriction | No restriction |
| 3 | HIGH SEVERITY only (security/crash/build) | Medium threshold (security, correctness, logic errors, resource leaks) |
| 4+ | HIGH SEVERITY only | HIGH SEVERITY only (security/crash/build) |

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes (35 tests)
- [x] `automation-cli review precommit --help` shows correct usage
- [x] Release binary built and installed locally
- [ ] PR validation pipeline exercises the review respond flow

![Reaction](https://raw.githubusercontent.com/AndrewAltimit/Media/refs/heads/main/reaction/miku_typing.webp)

Generated with [Claude Code](https://claude.com/claude-code)
