### PR TITLE
fix(pr-monitor): generic AI review classifier + cleanup reminder text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,11 @@ automation-cli ci run full > /tmp/ci-output.log 2>&1 && echo "CI passed" || (ech
 ### PR Monitoring
 
 ```bash
-./tools/rust/pr-monitor/target/release/pr-monitor 48
-./tools/rust/pr-monitor/target/release/pr-monitor 48 --since-commit abc1234
+pr-monitor 48
+pr-monitor 48 --since-commit abc1234
 ```
+
+(Install via `tools/rust/pr-monitor/install.sh` to put the binary on `$PATH`.)
 
 **For complete command reference, see** `docs/agents/README.md#running-agents-locally`
 

--- a/automation/setup/git/hooks/pre-push
+++ b/automation/setup/git/hooks/pre-push
@@ -75,14 +75,14 @@ You're pushing commits to PR #${pr_number} on branch '${current_branch}'.
 After push completes, consider monitoring for feedback:
 
   Monitor from this commit onwards:
-     ./tools/rust/pr-monitor/target/release/pr-monitor ${pr_number} --since-commit ${latest_commit}
+     pr-monitor ${pr_number} --since-commit ${latest_commit}
 
   Or monitor all new comments:
-     ./tools/rust/pr-monitor/target/release/pr-monitor ${pr_number}
+     pr-monitor ${pr_number}
 
 This will watch for:
   - Admin comments and commands
-  - Gemini AI code review feedback
+  - AI agent code review feedback
   - CI/CD validation results
 
 The monitor will return structured JSON when relevant comments are detected.

--- a/docs/agents/pr-monitoring.md
+++ b/docs/agents/pr-monitoring.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The PR Monitoring System allows Claude Code to continuously monitor Pull Requests for new comments from administrators and AI reviewers (like Gemini), automatically detecting when responses are needed.
+The PR Monitoring System allows Claude Code to continuously monitor Pull Requests for new comments from administrators and AI reviewers (Claude, OpenRouter, etc.), automatically detecting when responses are needed.
 
 ## Architecture
 
@@ -39,22 +39,22 @@ docker compose --profile ci run --rm rust-ci cargo build --release -p pr-monitor
 
 ```bash
 # Basic monitoring (10 minute timeout, 5 second poll interval)
-./tools/rust/pr-monitor/target/release/pr-monitor 48
+pr-monitor 48
 
 # With custom timeout (30 minutes)
-./tools/rust/pr-monitor/target/release/pr-monitor 48 --timeout 1800
+pr-monitor 48 --timeout 1800
 
 # JSON output only (for automation)
-./tools/rust/pr-monitor/target/release/pr-monitor 48 --json
+pr-monitor 48 --json
 
 # Monitor comments after a specific commit
-./tools/rust/pr-monitor/target/release/pr-monitor 48 --since-commit abc1234
+pr-monitor 48 --since-commit abc1234
 
 # Custom poll interval (check every 10 seconds)
-./tools/rust/pr-monitor/target/release/pr-monitor 48 --poll-interval 10
+pr-monitor 48 --poll-interval 10
 
 # Combine options
-./tools/rust/pr-monitor/target/release/pr-monitor 48 --since-commit abc1234 --timeout 1800 --json
+pr-monitor 48 --since-commit abc1234 --timeout 1800 --json
 ```
 
 ### In Claude Code
@@ -62,7 +62,7 @@ docker compose --profile ci run --rm rust-ci cargo build --release -p pr-monitor
 When working with PRs, you can end tasks with:
 - "...and monitor the PR for new comments"
 - "...then watch for admin responses"
-- "...and wait for Gemini's review"
+- "...and wait for the AI review"
 
 Claude will automatically start the monitoring tool.
 
@@ -70,7 +70,7 @@ Claude will automatically start the monitoring tool.
 
 ```bash
 # Run monitor and capture JSON output
-result=$(./tools/rust/pr-monitor/target/release/pr-monitor 48 --json 2>/dev/null)
+result=$(pr-monitor 48 --json 2>/dev/null)
 
 if [ $? -eq 0 ]; then
     echo "Relevant comment found:"
@@ -102,7 +102,7 @@ The monitoring tool returns structured JSON:
 |------|--------|---------|----------|----------------|
 | `admin_command` | Admin user | Contains `[ADMIN]` | High | Yes |
 | `admin_comment` | Admin user | Any comment | Normal | Yes |
-| `gemini_review` | github-actions | Contains "Gemini" | Normal | Yes |
+| `ai_agent_review` | github-actions | Standard AI review header or `<!-- {agent}-review-marker:commit:... -->` | Normal | Yes |
 | `ci_results` | github-actions | Contains "PR Validation Results" | Low | No |
 
 ### Exit Codes
@@ -117,7 +117,7 @@ The monitoring tool returns structured JSON:
 
 The monitor checks for comments from:
 - **AndrewAltimit** (repository admin)
-- **github-actions** (bot comments, including Gemini reviews)
+- **github-actions** (bot comments, including AI agent reviews)
 
 Monitoring parameters:
 - Default poll interval: 5 seconds
@@ -159,14 +159,14 @@ You're pushing commits to PR #48 on branch 'feature-branch'.
 After push completes, consider monitoring for feedback:
 
   Monitor from this commit onwards:
-     ./tools/rust/pr-monitor/target/release/pr-monitor 48 --since-commit abc1234
+     pr-monitor 48 --since-commit abc1234
 
   Or monitor all new comments:
-     ./tools/rust/pr-monitor/target/release/pr-monitor 48
+     pr-monitor 48
 
 This will watch for:
   - Admin comments and commands
-  - Gemini AI code review feedback
+  - AI agent code review feedback
   - CI/CD validation results
 
 The monitor will return structured JSON when relevant comments are detected.
@@ -192,7 +192,7 @@ User: Update the PR with the fixes and monitor for reviews
 Claude: I'll update the PR and then monitor for feedback.
 [Makes changes and pushes]
 [Starts monitoring]
-[Responds when admin/Gemini comments]
+[Responds when admin or AI reviewer comments]
 ```
 
 ### Example 2: Direct Monitoring
@@ -243,7 +243,7 @@ Claude: Admin posted: "[ADMIN] Please add tests"
 
 Increase timeout for long-running reviews:
 ```bash
-./tools/rust/pr-monitor/target/release/pr-monitor 48 --timeout 3600  # 1 hour
+pr-monitor 48 --timeout 3600  # 1 hour
 ```
 
 ### Graceful Shutdown
@@ -298,7 +298,7 @@ tools/rust/pr-monitor/
 
 4. **Combine with CI/CD**:
    - Monitor for both human and automated feedback
-   - Gemini reviews typically arrive within 2-5 minutes
+   - AI agent reviews typically arrive within 2-5 minutes
    - Admin comments may take longer
 
 ### Interactive Mode Workflow

--- a/docs/infrastructure/git-hooks.md
+++ b/docs/infrastructure/git-hooks.md
@@ -17,7 +17,7 @@ When you run `git push`, the hook will:
 
 1. Check if your branch has an open PR
 2. Display monitoring instructions with the correct PR number and commit SHA
-3. Remind you about the types of feedback to watch for (admin comments, Gemini reviews, CI/CD)
+3. Remind you about the types of feedback to watch for (admin comments, AI agent reviews, CI/CD)
 
 ### Example Output
 
@@ -30,14 +30,14 @@ You're pushing commits to PR #54 on branch 'refine'.
 After push completes, consider monitoring for feedback:
 
   Monitor from this commit onwards:
-     ./tools/rust/pr-monitor/target/release/pr-monitor 54 --since-commit abc1234
+     pr-monitor 54 --since-commit abc1234
 
   Or monitor all new comments:
-     ./tools/rust/pr-monitor/target/release/pr-monitor 54
+     pr-monitor 54
 
 This will watch for:
   - Admin comments and commands
-  - Gemini AI code review feedback
+  - AI agent code review feedback
   - CI/CD validation results
 
 The monitor will return structured data when relevant comments are detected.

--- a/tools/rust/gh-validator/src/main.rs
+++ b/tools/rust/gh-validator/src/main.rs
@@ -273,16 +273,13 @@ fn print_pr_monitoring_notice(pr_number: u32, pr_url: &str) {
     eprintln!("PR #{} created on branch '{}'", pr_number, branch);
     eprintln!("{}", pr_url);
     eprintln!();
-    eprintln!("To monitor for admin/Gemini feedback:");
+    eprintln!("To monitor for admin and AI agent review feedback:");
     eprintln!();
-    eprintln!(
-        "  ./tools/rust/pr-monitor/target/release/pr-monitor {} --since-commit {}",
-        pr_number, commit_sha
-    );
+    eprintln!("  pr-monitor {} --since-commit {}", pr_number, commit_sha);
     eprintln!();
     eprintln!("This will watch for:");
     eprintln!("  - Admin comments and approval commands");
-    eprintln!("  - Gemini AI code review feedback");
+    eprintln!("  - AI agent code review feedback");
     eprintln!("  - CI/CD validation results");
     eprintln!();
     eprintln!("============================================================");

--- a/tools/rust/gh-validator/src/validation/secrets.rs
+++ b/tools/rust/gh-validator/src/validation/secrets.rs
@@ -83,7 +83,7 @@ impl SecretMasker {
         // Sort secrets by length (longest first) to avoid partial masking
         // e.g., mask "SUPER_SECRET" before "SECRET"
         let mut sorted_secrets: Vec<_> = self.secrets.iter().collect();
-        sorted_secrets.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        sorted_secrets.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
         // Mask environment variable values
         for (name, value) in sorted_secrets {

--- a/tools/rust/github-agents-cli/README.md
+++ b/tools/rust/github-agents-cli/README.md
@@ -67,8 +67,8 @@ The CLI provides a complete native Rust implementation:
 For simple PR monitoring (watching for specific comments), use the dedicated `pr-monitor` tool:
 
 ```bash
-# Simple PR comment monitoring
-tools/rust/pr-monitor/target/release/pr-monitor 123
+# Simple PR comment monitoring (install via tools/rust/pr-monitor/install.sh)
+pr-monitor 123
 
 # Full PR monitoring with AI review processing (uses this CLI)
 github-agents pr-monitor

--- a/tools/rust/pr-monitor/README.md
+++ b/tools/rust/pr-monitor/README.md
@@ -4,12 +4,12 @@
 
 ## Overview
 
-`pr-monitor` watches a GitHub Pull Request for comments from administrators or AI reviewers (like Gemini). When a relevant comment is detected, it outputs a structured JSON decision that can be used by automation tools or AI agents.
+`pr-monitor` watches a GitHub Pull Request for comments from administrators or AI agent reviewers (Claude, OpenRouter, etc.). When a relevant comment is detected, it outputs a structured JSON decision that can be used by automation tools or AI agents.
 
 ## Features
 
 - **Polling-based monitoring** - Checks for new comments at configurable intervals
-- **Intelligent classification** - Categorizes comments as admin commands, admin feedback, Gemini reviews, or CI results
+- **Intelligent classification** - Categorizes comments as admin commands, admin feedback, AI agent reviews, or CI results
 - **Commit-based filtering** - Optionally only monitor comments after a specific commit
 - **JSON output** - Structured output for automation integration
 - **Graceful shutdown** - Handles Ctrl+C for clean interruption
@@ -85,7 +85,7 @@ When a relevant comment is found, the tool outputs a JSON decision:
 |------|--------|---------|----------------|
 | `admin_command` | Admin user | Contains `[ADMIN]` | Yes (High priority) |
 | `admin_comment` | Admin user | Any comment | Yes (Normal priority) |
-| `gemini_review` | github-actions | Contains "Gemini" | Yes (Normal priority) |
+| `ai_agent_review` | github-actions | Standard AI review header (`## {Agent} AI ... Review`) or `<!-- {agent}-review-marker:commit:... -->` | Yes (Normal priority) |
 | `ci_results` | github-actions | Contains "PR Validation Results" | No (Low priority) |
 
 ## Configuration

--- a/tools/rust/pr-monitor/src/analysis/classifier.rs
+++ b/tools/rust/pr-monitor/src/analysis/classifier.rs
@@ -97,6 +97,12 @@ static AI_REVIEW_HEADER_PATTERN: Lazy<Regex> =
 /// Pattern to detect existing agent response to a comment.
 /// `(?i)` matches the case-insensitivity of `AI_REVIEW_MARKER_PATTERN` so
 /// mixed-case agent slugs (if ever emitted) are still detected.
+///
+/// NOTE: The pattern requires a literal single space before `-->`
+/// (`([^>]+) -->`). Markers without that space (e.g. `...:abc123-->`) will
+/// silently fail to match. This matches the canonical format produced by the
+/// response pipeline; future marker generators must preserve the trailing
+/// ` -->` (space + arrow) suffix.
 #[allow(dead_code)] // Part of public API for library consumers
 static RESPONSE_MARKER_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?i)<!-- ai-agent-[a-z0-9_-]+-response:([^>]+) -->").unwrap());
@@ -379,6 +385,24 @@ mod tests {
         );
         let metadata = classification.review_metadata.unwrap();
         assert_eq!(metadata.commit_sha, Some("789abc".to_string()));
+    }
+
+    #[test]
+    fn test_codex_review_still_classified() {
+        // Legacy Codex review format must still classify as an AI agent review.
+        let comment = make_comment(
+            "github-actions[bot]",
+            "## Codex AI Code Review\n<!-- codex-review-marker:commit:0123abcd -->\n\nLGTM",
+        );
+        let classification = classify(&comment, "AndrewAltimit");
+
+        assert!(classification.needs_response);
+        assert_eq!(
+            classification.response_type,
+            Some(ResponseType::AiAgentReview)
+        );
+        let metadata = classification.review_metadata.unwrap();
+        assert_eq!(metadata.commit_sha, Some("0123abcd".to_string()));
     }
 
     #[test]

--- a/tools/rust/pr-monitor/src/analysis/classifier.rs
+++ b/tools/rust/pr-monitor/src/analysis/classifier.rs
@@ -85,13 +85,21 @@ static AI_REVIEW_MARKER_PATTERN: Lazy<Regex> = Lazy::new(|| {
 /// `## OpenRouter AI Code Review`).
 /// Anchored to a line that starts with `##` so status tables and inline
 /// mentions don't false-positive.
+///
+/// NOTE: This pattern requires `AI` to appear BEFORE `Review` on the heading
+/// line, matching the canonical format produced by the review pipeline. A
+/// heading that puts the tokens in the reverse order (e.g.
+/// `## Code Review AI Summary`) will not match. If a future reviewer adopts
+/// such a format, update this pattern accordingly.
 static AI_REVIEW_HEADER_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?im)^\s*##[^\n]*\bAI\b[^\n]*\bReview\b").unwrap());
 
-/// Pattern to detect existing agent response to a comment
+/// Pattern to detect existing agent response to a comment.
+/// `(?i)` matches the case-insensitivity of `AI_REVIEW_MARKER_PATTERN` so
+/// mixed-case agent slugs (if ever emitted) are still detected.
 #[allow(dead_code)] // Part of public API for library consumers
 static RESPONSE_MARKER_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"<!-- ai-agent-[a-z0-9_-]+-response:([^>]+) -->").unwrap());
+    Lazy::new(|| Regex::new(r"(?i)<!-- ai-agent-[a-z0-9_-]+-response:([^>]+) -->").unwrap());
 
 /// Pattern to detect [Action][Agent] trigger format
 static TRIGGER_PATTERN: Lazy<Regex> =

--- a/tools/rust/pr-monitor/src/analysis/classifier.rs
+++ b/tools/rust/pr-monitor/src/analysis/classifier.rs
@@ -15,8 +15,7 @@ use crate::github::Comment;
 pub enum Action {
     ExecuteAdminCommand,
     ReviewAdminFeedback,
-    AddressGeminiReview,
-    AddressCodexReview,
+    AddressAiAgentReview,
     ReviewCiResults,
 }
 
@@ -25,8 +24,7 @@ impl fmt::Display for Action {
         match self {
             Action::ExecuteAdminCommand => write!(f, "Execute admin command and respond"),
             Action::ReviewAdminFeedback => write!(f, "Review and respond to admin feedback"),
-            Action::AddressGeminiReview => write!(f, "Address Gemini code review feedback"),
-            Action::AddressCodexReview => write!(f, "Address Codex code review feedback"),
+            Action::AddressAiAgentReview => write!(f, "Address AI agent code review feedback"),
             Action::ReviewCiResults => write!(f, "Review CI results if failures present"),
         }
     }
@@ -65,43 +63,35 @@ impl Classification {
 pub const DEFAULT_ADMIN_USER: &str = "AndrewAltimit";
 
 // ============================================================================
-// Regex patterns ported from Python monitors/pr.py
+// Regex patterns for detecting AI agent review comments
 // ============================================================================
+//
+// All AI reviewers (Claude, Gemini, OpenRouter, Codex, etc.) post comments using
+// the same canonical format produced by the review pipeline:
+//   ## {Agent} AI [Incremental] {Type} Review
+//   <!-- {agent}-review-marker:commit:{sha} -->
+//
+// Detection looks for either the marker (most reliable) or a heading line
+// containing both "AI" and "Review" tokens.
 
-/// Patterns to detect Gemini review comments
-static GEMINI_PATTERNS: Lazy<[Regex; 4]> = Lazy::new(|| {
-    [
-        Regex::new(r"(?i)(?:gemini|google)\s*(?:ai\s*)?(?:code\s*)?review").unwrap(),
-        Regex::new(r"(?i)##\s*(?:ai\s*)?code\s*review").unwrap(),
-        Regex::new(r"(?i)automated\s*(?:code\s*)?review\s*(?:by|from)\s*gemini").unwrap(),
-        Regex::new(r"(?i)\*\*gemini\s*review\*\*").unwrap(),
-    ]
+/// HTML comment marker: `<!-- {agent}-review-marker:commit:{sha} -->`
+/// Capture group 1 is the agent slug, capture group 2 is the commit SHA.
+static AI_REVIEW_MARKER_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)<!--\s*([a-z0-9_-]+)-review-marker:commit:([a-f0-9]+)\s*-->").unwrap()
 });
 
-/// Patterns to detect Codex review comments
-static CODEX_PATTERNS: Lazy<[Regex; 5]> = Lazy::new(|| {
-    [
-        Regex::new(r"(?i)(?:codex|openai)\s*(?:ai\s*)?(?:code\s*)?review").unwrap(),
-        Regex::new(r"(?i)##\s*codex\s*(?:ai\s*)?(?:code\s*)?review").unwrap(),
-        Regex::new(r"(?i)automated\s*(?:code\s*)?review\s*(?:by|from)\s*codex").unwrap(),
-        Regex::new(r"(?i)\*\*codex\s*review\*\*").unwrap(),
-        Regex::new(r"(?i)codex-review-marker:commit:").unwrap(),
-    ]
-});
-
-/// Pattern to extract commit SHA from Gemini review marker
-static GEMINI_COMMIT_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)gemini-review-marker:commit:([a-f0-9]+)").unwrap());
-
-/// Pattern to extract commit SHA from Codex review marker
-static CODEX_COMMIT_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)codex-review-marker:commit:([a-f0-9]+)").unwrap());
+/// Heading line containing both "AI" and "Review" tokens (e.g.
+/// `## Claude AI Security & Correctness Review`,
+/// `## OpenRouter AI Code Review`).
+/// Anchored to a line that starts with `##` so status tables and inline
+/// mentions don't false-positive.
+static AI_REVIEW_HEADER_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?im)^\s*##[^\n]*\bAI\b[^\n]*\bReview\b").unwrap());
 
 /// Pattern to detect existing agent response to a comment
 #[allow(dead_code)] // Part of public API for library consumers
-static RESPONSE_MARKER_PATTERN: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"<!-- ai-agent-(?:gemini|codex|consolidated)-response:([^>]+) -->").unwrap()
-});
+static RESPONSE_MARKER_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"<!-- ai-agent-[a-z0-9_-]+-response:([^>]+) -->").unwrap());
 
 /// Pattern to detect [Action][Agent] trigger format
 static TRIGGER_PATTERN: Lazy<Regex> =
@@ -111,58 +101,23 @@ static TRIGGER_PATTERN: Lazy<Regex> =
 // Classification functions
 // ============================================================================
 
-/// Check if comment body matches Gemini review patterns
-fn is_gemini_review(body: &str) -> bool {
-    // Must contain actual review marker or header, not just status table mention
-    if body.contains("gemini-review-marker") || body.contains("## Gemini AI") {
-        return true;
+/// Check if a comment body is an AI agent code review.
+///
+/// Matches the canonical review-pipeline format used by all reviewers
+/// (Claude, Gemini, OpenRouter, Codex, ...). Status tables that happen to
+/// reference reviews are excluded so they get classified as `CiResults`.
+fn is_ai_agent_review(body: &str) -> bool {
+    if body.contains("PR Validation Results") {
+        return false;
     }
-
-    // Check against Python patterns
-    for pattern in GEMINI_PATTERNS.iter() {
-        if pattern.is_match(body) {
-            // Exclude CI status tables that mention reviews
-            if !body.contains("PR Validation Results") {
-                return true;
-            }
-        }
-    }
-
-    false
+    AI_REVIEW_MARKER_PATTERN.is_match(body) || AI_REVIEW_HEADER_PATTERN.is_match(body)
 }
 
-/// Check if comment body matches Codex review patterns
-fn is_codex_review(body: &str) -> bool {
-    // Must contain actual review marker or header
-    if body.contains("codex-review-marker") || body.contains("## Codex AI") {
-        return true;
-    }
-
-    // Check against Python patterns
-    for pattern in CODEX_PATTERNS.iter() {
-        if pattern.is_match(body) {
-            // Exclude CI status tables
-            if !body.contains("PR Validation Results") {
-                return true;
-            }
-        }
-    }
-
-    false
-}
-
-/// Extract commit SHA from Gemini review marker
-pub fn extract_gemini_commit_sha(body: &str) -> Option<String> {
-    GEMINI_COMMIT_PATTERN
+/// Extract commit SHA from any AI agent review marker
+pub fn extract_review_commit_sha(body: &str) -> Option<String> {
+    AI_REVIEW_MARKER_PATTERN
         .captures(body)
-        .map(|caps| caps.get(1).unwrap().as_str().to_string())
-}
-
-/// Extract commit SHA from Codex review marker
-pub fn extract_codex_commit_sha(body: &str) -> Option<String> {
-    CODEX_COMMIT_PATTERN
-        .captures(body)
-        .map(|caps| caps.get(1).unwrap().as_str().to_string())
+        .and_then(|caps| caps.get(2).map(|m| m.as_str().to_string()))
 }
 
 /// Check if a response marker exists for the given review ID
@@ -237,36 +192,16 @@ pub fn classify(comment: &Comment, admin_user: &str) -> Classification {
 
     // GitHub Actions bot
     if author.contains("github-actions") {
-        // Check for Gemini review
-        if is_gemini_review(body) {
-            let commit_sha = extract_gemini_commit_sha(body);
+        // AI agent review (Claude, Gemini, OpenRouter, Codex, ...)
+        if is_ai_agent_review(body) {
+            let commit_sha = extract_review_commit_sha(body);
             let review_id = generate_review_id(comment);
 
             return Classification {
                 needs_response: true,
                 priority: Priority::Normal,
-                response_type: Some(ResponseType::GeminiReview),
-                action: Some(Action::AddressGeminiReview),
-                review_metadata: Some(ReviewMetadata {
-                    commit_sha,
-                    review_id: Some(review_id),
-                    trigger_action: None,
-                    trigger_agent: None,
-                    already_responded: false,
-                }),
-            };
-        }
-
-        // Check for Codex review
-        if is_codex_review(body) {
-            let commit_sha = extract_codex_commit_sha(body);
-            let review_id = generate_review_id(comment);
-
-            return Classification {
-                needs_response: true,
-                priority: Priority::Normal,
-                response_type: Some(ResponseType::CodexReview),
-                action: Some(Action::AddressCodexReview),
+                response_type: Some(ResponseType::AiAgentReview),
+                action: Some(Action::AddressAiAgentReview),
                 review_metadata: Some(ReviewMetadata {
                     commit_sha,
                     review_id: Some(review_id),
@@ -381,10 +316,10 @@ mod tests {
     }
 
     #[test]
-    fn test_gemini_review_classification() {
+    fn test_claude_review_classification() {
         let comment = make_comment(
             "github-actions[bot]",
-            "## Gemini AI Incremental Review\n<!-- gemini-review-marker:commit:abc123 -->\n\nThis looks good overall...",
+            "## Claude AI Security & Correctness Review\n<!-- claude-review-marker:commit:abc123 -->\n\nThis looks good overall...",
         );
         let classification = classify(&comment, "AndrewAltimit");
 
@@ -392,9 +327,9 @@ mod tests {
         assert_eq!(classification.priority, Priority::Normal);
         assert_eq!(
             classification.response_type,
-            Some(ResponseType::GeminiReview)
+            Some(ResponseType::AiAgentReview)
         );
-        assert_eq!(classification.action, Some(Action::AddressGeminiReview));
+        assert_eq!(classification.action, Some(Action::AddressAiAgentReview));
 
         let metadata = classification.review_metadata.unwrap();
         assert_eq!(metadata.commit_sha, Some("abc123".to_string()));
@@ -402,31 +337,61 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_review_classification() {
+    fn test_openrouter_review_classification() {
         let comment = make_comment(
             "github-actions[bot]",
-            "## Codex AI Code Review\n<!-- codex-review-marker:commit:def456 -->\n\nLGTM",
+            "## Openrouter AI Incremental General Review\n<!-- openrouter-review-marker:commit:def456 -->\n\n*This is an incremental review focusing on changes since the last review.*\n\n## Issues (if any)\n\n(none)",
         );
         let classification = classify(&comment, "AndrewAltimit");
 
         assert!(classification.needs_response);
-        assert_eq!(classification.priority, Priority::Normal);
         assert_eq!(
             classification.response_type,
-            Some(ResponseType::CodexReview)
+            Some(ResponseType::AiAgentReview)
         );
-        assert_eq!(classification.action, Some(Action::AddressCodexReview));
+        assert_eq!(classification.action, Some(Action::AddressAiAgentReview));
 
         let metadata = classification.review_metadata.unwrap();
         assert_eq!(metadata.commit_sha, Some("def456".to_string()));
     }
 
     #[test]
-    fn test_status_table_not_classified_as_review() {
-        // Status table contains "Gemini review" text but shouldn't be classified as actual review
+    fn test_gemini_review_still_classified() {
+        // Legacy Gemini review format must still classify as an AI agent review.
         let comment = make_comment(
             "github-actions[bot]",
-            "## PR Validation Results\n\n| Check | Status |\n| Gemini review | :white_check_mark: |",
+            "## Gemini AI Incremental Review\n<!-- gemini-review-marker:commit:789abc -->\n\nLGTM",
+        );
+        let classification = classify(&comment, "AndrewAltimit");
+
+        assert!(classification.needs_response);
+        assert_eq!(
+            classification.response_type,
+            Some(ResponseType::AiAgentReview)
+        );
+        let metadata = classification.review_metadata.unwrap();
+        assert_eq!(metadata.commit_sha, Some("789abc".to_string()));
+    }
+
+    #[test]
+    fn test_review_response_agent_not_classified_as_review() {
+        // Review Response Agent comments are responses, not reviews — must not match.
+        let comment = make_comment(
+            "github-actions[bot]",
+            "## Review Response Agent (Iteration 1)\n<!-- agent-metadata:type=review-fix:iteration=1 -->\n\n**Status:** Changes committed, pushing...",
+        );
+        let classification = classify(&comment, "AndrewAltimit");
+
+        assert!(!classification.needs_response);
+        assert!(classification.response_type.is_none());
+    }
+
+    #[test]
+    fn test_status_table_not_classified_as_review() {
+        // Status table mentions reviews in cells but shouldn't be classified as a review.
+        let comment = make_comment(
+            "github-actions[bot]",
+            "## PR Validation Results\n\n| Check | Status |\n|-------|--------|\n| Claude security-review | pass |\n| Openrouter review | pass |",
         );
         let classification = classify(&comment, "AndrewAltimit");
 
@@ -467,24 +432,29 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_gemini_commit_sha() {
-        let body = "Some review text\n<!-- gemini-review-marker:commit:abc123def -->\nMore text";
-        assert_eq!(
-            extract_gemini_commit_sha(body),
-            Some("abc123def".to_string())
-        );
-
-        let body_no_marker = "Some review without marker";
-        assert_eq!(extract_gemini_commit_sha(body_no_marker), None);
-    }
-
-    #[test]
-    fn test_extract_codex_commit_sha() {
-        let body = "Review\n<!-- codex-review-marker:commit:789abcdef -->";
-        assert_eq!(
-            extract_codex_commit_sha(body),
-            Some("789abcdef".to_string())
-        );
+    fn test_extract_review_commit_sha() {
+        // Works for any agent slug
+        for (body, expected) in [
+            (
+                "<!-- claude-review-marker:commit:abc123def -->",
+                Some("abc123def".to_string()),
+            ),
+            (
+                "<!-- openrouter-review-marker:commit:cafe1234 -->",
+                Some("cafe1234".to_string()),
+            ),
+            (
+                "<!-- gemini-review-marker:commit:beef5678 -->",
+                Some("beef5678".to_string()),
+            ),
+            (
+                "<!-- codex-review-marker:commit:0123abcd -->",
+                Some("0123abcd".to_string()),
+            ),
+            ("Some review without marker", None),
+        ] {
+            assert_eq!(extract_review_commit_sha(body), expected, "body: {body}");
+        }
     }
 
     #[test]
@@ -501,34 +471,46 @@ mod tests {
     }
 
     #[test]
-    fn test_gemini_pattern_matching() {
-        // Should match
-        assert!(is_gemini_review("## Gemini AI Code Review"));
-        assert!(is_gemini_review(
-            "Automated code review by Gemini\nSome feedback"
-        ));
-        assert!(is_gemini_review("**gemini review**"));
-        assert!(is_gemini_review("<!-- gemini-review-marker:commit:abc -->"));
+    fn test_ai_review_pattern_matching() {
+        // Headers from each known reviewer (canonical format)
+        for body in [
+            "## Claude AI Security & Correctness Review",
+            "## Claude AI Architecture & Quality Review",
+            "## Claude AI Incremental Security & Correctness Review",
+            "## Openrouter AI General Review",
+            "## OpenRouter AI Code Review",
+            "## Openrouter AI Incremental General Review",
+            "## Gemini AI Incremental Review",
+            "## Codex AI Code Review",
+        ] {
+            assert!(is_ai_agent_review(body), "expected match: {body}");
+        }
 
-        // Should not match
-        assert!(!is_gemini_review(
-            "## PR Validation Results\n| Gemini review | passed |"
-        ));
-        assert!(!is_gemini_review("random comment"));
-    }
+        // Markers alone are sufficient
+        for body in [
+            "<!-- claude-review-marker:commit:abc -->",
+            "<!-- openrouter-review-marker:commit:abc -->",
+            "<!-- gemini-review-marker:commit:abc -->",
+            "<!-- codex-review-marker:commit:abc -->",
+        ] {
+            assert!(is_ai_agent_review(body), "expected match: {body}");
+        }
 
-    #[test]
-    fn test_codex_pattern_matching() {
-        // Should match
-        assert!(is_codex_review("## Codex AI Code Review"));
-        assert!(is_codex_review("Automated review from Codex"));
-        assert!(is_codex_review("**codex review**"));
-        assert!(is_codex_review("codex-review-marker:commit:abc"));
-
-        // Should not match
-        assert!(!is_codex_review(
-            "## PR Validation Results\n| Codex review | passed |"
-        ));
-        assert!(!is_codex_review("random comment"));
+        // Must NOT match
+        for body in [
+            // Status tables that mention reviews
+            "## PR Validation Results\n| Claude security-review | pass |",
+            "## PR Validation Results\n| Openrouter review | pass |",
+            // Review Response Agent (these are responses, not reviews)
+            "## Review Response Agent (Iteration 5)",
+            // Inline mention without canonical heading
+            "I just got a review from gemini",
+            // Random comment
+            "random comment",
+            // Heading without "AI" token
+            "## Code Review Summary",
+        ] {
+            assert!(!is_ai_agent_review(body), "expected no match: {body}");
+        }
     }
 }

--- a/tools/rust/pr-monitor/src/analysis/decision.rs
+++ b/tools/rust/pr-monitor/src/analysis/decision.rs
@@ -20,8 +20,7 @@ pub enum Priority {
 pub enum ResponseType {
     AdminCommand,
     AdminComment,
-    GeminiReview,
-    CodexReview,
+    AiAgentReview,
     CiResults,
 }
 
@@ -96,8 +95,8 @@ mod tests {
             "\"admin_command\""
         );
         assert_eq!(
-            serde_json::to_string(&ResponseType::GeminiReview).unwrap(),
-            "\"gemini_review\""
+            serde_json::to_string(&ResponseType::AiAgentReview).unwrap(),
+            "\"ai_agent_review\""
         );
     }
 
@@ -159,8 +158,8 @@ mod tests {
         let decision = Decision {
             needs_response: true,
             priority: Priority::Normal,
-            response_type: Some(ResponseType::GeminiReview),
-            action_required: Some("Address Gemini code review feedback".to_string()),
+            response_type: Some(ResponseType::AiAgentReview),
+            action_required: Some("Address AI agent code review feedback".to_string()),
             review_metadata: Some(ReviewMetadata {
                 commit_sha: Some("def456".to_string()),
                 review_id: Some("2026-01-18-12-00-00".to_string()),
@@ -171,12 +170,12 @@ mod tests {
             comment: CommentSummary {
                 author: "github-actions[bot]".to_string(),
                 timestamp: "2026-01-18T12:00:00Z".to_string(),
-                body: "## Gemini AI Review\n...".to_string(),
+                body: "## Claude AI Review\n...".to_string(),
             },
         };
 
         let json = serde_json::to_string_pretty(&decision).unwrap();
-        assert!(json.contains("\"gemini_review\""));
+        assert!(json.contains("\"ai_agent_review\""));
         assert!(json.contains("\"commit_sha\": \"def456\""));
         assert!(json.contains("\"review_id\": \"2026-01-18-12-00-00\""));
     }

--- a/tools/rust/pr-monitor/src/analysis/mod.rs
+++ b/tools/rust/pr-monitor/src/analysis/mod.rs
@@ -6,8 +6,8 @@ mod decision;
 // Public API exports (some may not be used internally but are part of the library interface)
 #[allow(unused_imports)]
 pub use classifier::{
-    Action, Classification, DEFAULT_ADMIN_USER, classify, extract_codex_commit_sha,
-    extract_gemini_commit_sha, extract_trigger, has_response_marker, is_relevant_author,
+    Action, Classification, DEFAULT_ADMIN_USER, classify, extract_review_commit_sha,
+    extract_trigger, has_response_marker, is_relevant_author,
 };
 #[allow(unused_imports)]
 pub use decision::{CommentSummary, Decision, Priority, ResponseType, ReviewMetadata};


### PR DESCRIPTION
## Summary

The post-push reminder shown by `gh-validator` and the `pre-push` hook hardcoded a local cargo target path and named Gemini specifically. That's stale on two fronts:

1. `pr-monitor` is a PATH-installed binary now (`~/.local/bin/pr-monitor` via `tools/rust/pr-monitor/install.sh`), so suggesting `./tools/rust/pr-monitor/target/release/pr-monitor <PR>` is misleading.
2. The review pipeline currently runs Claude + OpenRouter (with Gemini/Codex disabled per `CLAUDE.md`), and all of these reviewers post comments in the same canonical format -- naming Gemini specifically in the reminder is wrong, and the underlying pr-monitor classifier had separate Gemini- and Codex-specific code paths.

This PR cleans up both layers and makes the classifier generic.

### Reminder cleanup
- `gh-validator` and the `pre-push` hook now suggest `pr-monitor <PR>` and refer to "AI agent code review feedback".
- Same wording propagated through `CLAUDE.md`, `docs/agents/pr-monitoring.md`, `docs/infrastructure/git-hooks.md`, `tools/rust/pr-monitor/README.md`, and `tools/rust/github-agents-cli/README.md`.

### Classifier refactor (pr-monitor)
- `ResponseType::{GeminiReview, CodexReview}` -> `AiAgentReview` (JSON: `"ai_agent_review"`).
- `Action::{AddressGeminiReview, AddressCodexReview}` -> `AddressAiAgentReview`.
- Two regex pairs collapsed into one generic pair:
  - `AI_REVIEW_MARKER_PATTERN` matches `<!-- {agent}-review-marker:commit:{sha} -->`
  - `AI_REVIEW_HEADER_PATTERN` matches `## ... AI ... Review` headings
- `is_gemini_review` + `is_codex_review` -> `is_ai_agent_review`.
- `extract_gemini_commit_sha` + `extract_codex_commit_sha` -> `extract_review_commit_sha`.
- `RESPONSE_MARKER_PATTERN` widened from `(?:gemini|codex|consolidated)` to any alphanumeric agent slug.

The new patterns match the canonical format every reviewer in the pipeline already uses (Claude, OpenRouter, Gemini, Codex), so future reviewers with the same template work without code changes.

### Tests
- Updated tests cover Claude, OpenRouter, Gemini, and Codex headers and markers all classifying as `AiAgentReview`.
- Negative tests confirm `## Review Response Agent (Iteration N)` comments and `## PR Validation Results` status tables don't false-positive (the latter mentions reviews in cells but isn't itself a review).

### Drive-by
- `gh-validator/src/validation/secrets.rs`: switched `sort_by` to `sort_by_key(Reverse(...))` to satisfy a new clippy 1.95.0 lint (`unnecessary_sort_by`) that was blocking the precommit hook on any gh-validator change.

### Out of scope (flagging)
- `docs/agents/auto-response.md` is a Gemini-centric document describing a Python `AgentJudgement` system (`security/judgement.py` no longer exists). The `DISABLE_GEMINI_AUTO_RESPONSE` env var it documents is set in `.github/workflows/pr-review-monitor.yml` but no current code reads it. Looks like dead documentation from a pre-Rust review system. Worth a follow-up to either delete it or rewrite for the current Rust review-agent.
- `docs/agents/board-workflow.md` has a "5a. Gemini Automated Review" / "5b. Codex Automated Review" section and an Agent Council ASCII diagram that still feature Gemini/Codex prominently; they're now opt-in-only via PR labels (`force-gemini-review`/`force-codex-review`), so the doc overstates their role.

## Test plan

- [x] `cargo test --release -p pr-monitor` -- 23/23 pass
- [x] `cargo fmt --check` clean (gh-validator, pr-monitor)
- [x] `cargo clippy --release --all-targets -- -D warnings` clean (gh-validator, pr-monitor)
- [x] Precommit hooks pass (ruff, yamllint, shellcheck, rust-fmt + rust-clippy on touched packages)
- [x] Local install verified: `~/.local/bin/gh` (non-setgid) and `/usr/bin/gh` (setgid root:wrapper-guard, mode 2755) both updated; `gh --version` resolves through the wrapper chain to real gh 2.45.0
- [ ] Reviewer to verify: a fresh `gh pr create` from this branch should print a single, non-duplicated reminder with the new wording (the duplication came from both wrapper copies running the post-create hook; both are now updated)