### PR TITLE
Harden Rust tooling: panic boundary, subprocess/HTTP timeouts, shared helpers, and tests

### DIFF
--- a/.agents.yaml
+++ b/.agents.yaml
@@ -97,12 +97,10 @@ model_overrides:
 
   # OpenRouter agents configuration
   opencode:
-    model: qwen/qwen-2.5-coder-32b-instruct
-    temperature: 0.2
+    model: qwen/qwen3.7-max
 
   crush:
-    model: qwen/qwen-2.5-coder-32b-instruct
-    temperature: 0.1  # Lower temperature for Crush
+    model: qwen/qwen3.7-max
 
   # DISABLED: OpenAI/Codex phased out due to mass surveillance and autonomous
   # kill decision concerns. Use Anthropic models instead.
@@ -112,14 +110,14 @@ model_overrides:
 
   # OpenRouter models (for openrouter agent)
   openrouter:
-    default_model: "qwen/qwen3.6-plus"
+    default_model: "qwen/qwen3.7-max"
 
 # OpenRouter configuration (for future agents)
 openrouter:
   # API key must be provided as OPENROUTER_API_KEY environment variable
 
   # Default model for OpenRouter-compatible agents
-  default_model: qwen/qwen-2.5-coder-32b-instruct
+  default_model: qwen/qwen3.7-max
 
   # Fallback models if primary is unavailable
   fallback_models:

--- a/.github/actions/docker-compose-health-check/action.yml
+++ b/.github/actions/docker-compose-health-check/action.yml
@@ -53,10 +53,20 @@ runs:
       shell: bash
       run: |
         echo "Creating output directories with proper permissions..."
-        # Create directories that will be bind-mounted to avoid permission issues
-        mkdir -p outputs/mcp-content outputs/mcp-gaea2
-        # Ensure they're writable by the current user
-        chmod -R 755 outputs/
+        # Pre-create ALL bind-mounted output dirs (incl. blender/*) as the
+        # runner user. Otherwise the Docker daemon (root) auto-creates missing
+        # bind-mount sources as root, and the next actions/checkout cleanup
+        # fails with EACCES trying to rmdir them. The canonical script also
+        # repairs any pre-existing root-owned dirs via a busybox chown.
+        if [ -f automation/setup/docker/init-output-dirs.sh ]; then
+          bash automation/setup/docker/init-output-dirs.sh
+        else
+          # Fallback if the script is unavailable for any reason.
+          mkdir -p outputs/mcp-content outputs/mcp-gaea2 \
+                   outputs/blender/projects outputs/blender/assets \
+                   outputs/blender/renders outputs/blender/templates
+          chmod -R 755 outputs/
+        fi
         echo "Output directories created"
 
     - name: Set Docker Compose profiles

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Active AI agents work together in this development ecosystem:
 3. ~~**Gemini CLI**~~ - ~~Automated PR code reviews~~ **DISABLED** -- Google updated its AI principles (Feb 2026) to allow mass surveillance and autonomous weapons use cases.
 4. **OpenCode** - Code generation via OpenRouter
 5. **Crush** - Code generation via OpenRouter
-6. **OpenRouter** - PR code review via Qwen model (qwen/qwen3.6-plus)
+6. **OpenRouter** - PR code review via Qwen model (qwen/qwen3.7-max)
 7. **GitHub Copilot** - Provides code review suggestions in PRs
 
 **For complete agent documentation, see** `docs/agents/README.md`

--- a/automation/setup/runner/job-started-hook.sh
+++ b/automation/setup/runner/job-started-hook.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Self-hosted runner job-started hook.
+#
+# Runs BEFORE every job on the runner (including before `actions/checkout`).
+# Its job is to remove root-owned bind-mount artifacts that a Docker container
+# may have left in the workspace (e.g. `outputs/`, `evaluation_results/`), so
+# checkout's clean step does not fail with:
+#
+#     Error: File was unable to be removed
+#     Error: EACCES: permission denied, rmdir '.../outputs/blender'
+#
+# Docker's daemon runs as root, so missing bind-mount source directories it
+# auto-creates (and anything a root container writes) are owned by root and the
+# unprivileged runner user cannot delete them. This hook uses busybox-as-root
+# via Docker to remove them without needing passwordless sudo -- the same
+# technique as .github/actions/pre-checkout-cleanup, but applied universally to
+# every workflow (and to leftovers from manual `docker compose` runs on the
+# host, which no per-workflow step can cover).
+#
+# ── Activation ────────────────────────────────────────────────────────────
+# Install this at a STABLE path OUTSIDE any workspace (the workspace is wiped
+# per job), then point the runner at it via its .env and restart the service:
+#
+#   install -m 0755 automation/setup/runner/job-started-hook.sh \
+#       "$HOME/.actions-runner-hooks/job-started.sh"
+#   echo 'ACTIONS_RUNNER_HOOK_JOB_STARTED='"$HOME"'/.actions-runner-hooks/job-started.sh' \
+#       >> /path/to/actions-runner/.env
+#   ( cd /path/to/actions-runner && sudo ./svc.sh stop && sudo ./svc.sh start )
+#
+# The hook always exits 0: a cleanup failure must never fail the job itself.
+
+set -u
+
+WS="${GITHUB_WORKSPACE:-}"
+
+# GITHUB_WORKSPACE may not be set for some job types; fall back to nothing.
+[ -n "$WS" ] || exit 0
+[ -d "$WS" ] || exit 0
+
+# Only the regenerable, gitignored artifacts are removed -- never source or
+# .git history.
+if command -v docker >/dev/null 2>&1; then
+    # Remove root-owned targets as root inside a throwaway container.
+    timeout 60 docker run --rm -v "$WS:/ws" busybox:1.36.1 \
+        sh -c 'rm -rf /ws/outputs /ws/evaluation_results /ws/.git/index.lock 2>/dev/null || true' \
+        >/dev/null 2>&1 || true
+else
+    # No Docker: best-effort as the runner user (handles non-root leftovers).
+    rm -rf "${WS:?}/outputs" "${WS:?}/evaluation_results" "${WS:?}/.git/index.lock" 2>/dev/null || true
+fi
+
+exit 0

--- a/automation/setup/runner/job-started-hook.sh
+++ b/automation/setup/runner/job-started-hook.sh
@@ -46,6 +46,9 @@ if command -v docker >/dev/null 2>&1; then
         >/dev/null 2>&1 || true
 else
     # No Docker: best-effort as the runner user (handles non-root leftovers).
+    # Root-owned artifacts CANNOT be removed on this path -- warn so a recurring
+    # checkout EACCES failure is traceable to the missing docker binary.
+    echo "job-started-hook: docker not found; cleaning as runner user only -- root-owned artifacts will be left in place" >&2
     rm -rf "${WS:?}/outputs" "${WS:?}/evaluation_results" "${WS:?}/.git/index.lock" 2>/dev/null || true
 fi
 

--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -171,6 +171,12 @@ You can also set allowed repositories via environment variable:
 export AI_AGENT_ALLOWED_REPOS="owner/repo1,owner/repo2"
 ```
 
+When no `.agents.yaml` is present, the security manager falls back to a
+built-in default admin. Override it (comma-separated) without editing config:
+```bash
+export AI_AGENT_DEFAULT_ADMIN="owner1,owner2"
+```
+
 ### 7. Security Manager (Rust CLI)
 
 The security functionality is implemented in Rust and available via the `github-agents` CLI:

--- a/docs/guides/agent-council-setup-guide.md
+++ b/docs/guides/agent-council-setup-guide.md
@@ -273,7 +273,7 @@ rate_limits:
 
 # OpenRouter settings
 openrouter:
-  default_model: qwen/qwen3.6-plus
+  default_model: qwen/qwen3.7-max
   fallback_models:
     - deepseek/deepseek-coder-v2-instruct
 
@@ -380,7 +380,7 @@ profiles:
   openrouter-general:
     display_name: "General Review"
     agent: openrouter
-    model: "qwen/qwen3.6-plus"
+    model: "qwen/qwen3.7-max"
     focus: "General code quality, logic errors, edge cases"
     instructions: |
       You are a GENERAL code reviewer providing a broad perspective. Focus on:
@@ -1157,7 +1157,7 @@ runs:
 Edit `review-profiles.yaml`. Each profile needs:
 - `display_name` -- shown in the PR comment header
 - `agent` -- `claude` or `openrouter`
-- `model` -- model name (e.g., `sonnet` for Claude, `qwen/qwen3.6-plus` for OpenRouter)
+- `model` -- model name (e.g., `sonnet` for Claude, `qwen/qwen3.7-max` for OpenRouter)
 - `focus` -- one-line description
 - `instructions` -- system prompt text prepended to the review
 

--- a/review-profiles.yaml
+++ b/review-profiles.yaml
@@ -78,7 +78,7 @@ profiles:
   openrouter-general:
     display_name: "General Review"
     agent: openrouter
-    model: "qwen/qwen3.6-plus"
+    model: "qwen/qwen3.7-max"
     focus: "General code quality, logic errors, edge cases"
     instructions: |
       You are a GENERAL code reviewer providing a broad perspective. Focus on:

--- a/tools/mcp/mcp_agentcore_memory/src/client.rs
+++ b/tools/mcp/mcp_agentcore_memory/src/client.rs
@@ -35,10 +35,7 @@ pub struct ChromaDBClient {
 impl ChromaDBClient {
     /// Create a new ChromaDB client
     pub fn new(config: ChromaDBConfig) -> Self {
-        let client = Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .expect("Failed to create HTTP client");
+        let client = mcp_core::http::build_client_or_default(std::time::Duration::from_secs(30));
 
         info!(
             "ChromaDB client configured: {}:{}",

--- a/tools/mcp/mcp_blender/README.md
+++ b/tools/mcp/mcp_blender/README.md
@@ -107,6 +107,7 @@ curl http://localhost:8017/mcp/tools
 | `BLENDER_PATH` | Auto-detect | Path to Blender executable |
 | `MAX_CONCURRENT_JOBS` | CPU/2 | Maximum concurrent Blender processes |
 | `CUDA_VISIBLE_DEVICES` | All | GPU device selection for rendering |
+| `BLENDER_JOB_TIMEOUT_SECS` | `600` | Per-job timeout for a Blender subprocess invocation |
 
 ## Architecture
 

--- a/tools/mcp/mcp_blender/src/blender.rs
+++ b/tools/mcp/mcp_blender/src/blender.rs
@@ -5,10 +5,16 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::process::Command;
 use tokio::sync::{RwLock, Semaphore};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
+
+/// Default wall-clock timeout for a single Blender invocation. A hung render
+/// must not block its worker task forever; override with
+/// `BLENDER_JOB_TIMEOUT_SECS`.
+const DEFAULT_JOB_TIMEOUT_SECS: u64 = 600;
 
 /// Script argument parsing patterns used by different Blender Python scripts
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -36,6 +42,9 @@ pub struct BlenderExecutor {
     semaphore: Arc<Semaphore>,
     /// Track running processes for cancellation
     processes: Arc<RwLock<HashMap<Uuid, tokio::process::Child>>>,
+    /// Per-invocation wall-clock timeout; on elapse the child is killed
+    /// (via `kill_on_drop`) and the job fails instead of hanging forever.
+    job_timeout: Duration,
 }
 
 impl BlenderExecutor {
@@ -68,6 +77,14 @@ impl BlenderExecutor {
             .unwrap_or_else(|| num_cpus::get() / 2)
             .max(1);
 
+        let job_timeout = Duration::from_secs(
+            std::env::var("BLENDER_JOB_TIMEOUT_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .filter(|&secs| secs > 0)
+                .unwrap_or(DEFAULT_JOB_TIMEOUT_SECS),
+        );
+
         Self {
             blender_path: Arc::new(RwLock::new(None)),
             scripts_dir,
@@ -76,6 +93,7 @@ impl BlenderExecutor {
             initialized: Arc::new(RwLock::new(false)),
             semaphore: Arc::new(Semaphore::new(max_concurrent)),
             processes: Arc::new(RwLock::new(HashMap::new())),
+            job_timeout,
         }
     }
 
@@ -278,21 +296,42 @@ impl BlenderExecutor {
             cmd.env("CUDA_VISIBLE_DEVICES", cuda_devices);
         }
 
-        // Spawn the process
+        // Spawn the process. `kill_on_drop` guarantees the OS process is killed
+        // if the future below is dropped (e.g. on timeout or task cancellation),
+        // so a runaway Blender cannot outlive its job.
         let child = cmd
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
             .spawn()
             .map_err(|e| MCPError::Internal(format!("Failed to spawn Blender: {}", e)))?;
 
-        // Note: Process cancellation would require storing Child handles differently.
-        // For now, cancellation is handled at the job level.
-
-        // Wait for completion
-        let output = child
-            .wait_with_output()
-            .await
-            .map_err(|e| MCPError::Internal(format!("Failed to wait for Blender: {}", e)))?;
+        // Wait for completion, bounded by the configured timeout. On timeout the
+        // `wait_with_output` future is dropped, which kills the child via
+        // `kill_on_drop`, and the job fails cleanly instead of hanging forever.
+        let output = match tokio::time::timeout(self.job_timeout, child.wait_with_output()).await {
+            Ok(Ok(output)) => output,
+            Ok(Err(e)) => {
+                self.cleanup_temp_file(temp_file).await;
+                return Err(MCPError::Internal(format!(
+                    "Failed to wait for Blender: {}",
+                    e
+                )));
+            },
+            Err(_elapsed) => {
+                self.cleanup_temp_file(temp_file).await;
+                error!(
+                    "Blender script {} (job {}) timed out after {}s; process killed",
+                    script_name,
+                    job_id,
+                    self.job_timeout.as_secs()
+                );
+                return Err(MCPError::Internal(format!(
+                    "Blender script timed out after {}s",
+                    self.job_timeout.as_secs()
+                )));
+            },
+        };
 
         // Remove from tracking
         {
@@ -301,11 +340,7 @@ impl BlenderExecutor {
         }
 
         // Clean up temp file if created
-        if let Some(temp_path) = temp_file
-            && let Err(e) = tokio::fs::remove_file(&temp_path).await
-        {
-            debug!("Failed to remove temp file {:?}: {}", temp_path, e);
-        }
+        self.cleanup_temp_file(temp_file).await;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -335,6 +370,16 @@ impl BlenderExecutor {
         });
 
         Ok(result)
+    }
+
+    /// Best-effort removal of a per-job temp args file. Logged at debug level on
+    /// failure so cleanup never masks the underlying job result.
+    async fn cleanup_temp_file(&self, temp_file: Option<PathBuf>) {
+        if let Some(temp_path) = temp_file
+            && let Err(e) = tokio::fs::remove_file(&temp_path).await
+        {
+            debug!("Failed to remove temp file {:?}: {}", temp_path, e);
+        }
     }
 
     /// Execute a script asynchronously (for long-running operations)
@@ -539,6 +584,7 @@ impl Clone for BlenderExecutor {
             initialized: self.initialized.clone(),
             semaphore: self.semaphore.clone(),
             processes: self.processes.clone(),
+            job_timeout: self.job_timeout,
         }
     }
 }

--- a/tools/mcp/mcp_comfyui/src/client.rs
+++ b/tools/mcp/mcp_comfyui/src/client.rs
@@ -21,10 +21,7 @@ pub struct ComfyUIClient {
 impl ComfyUIClient {
     /// Create a new ComfyUI client
     pub fn new(host: &str, port: u16, client_id: String, comfyui_path: &str) -> Self {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(300))
-            .build()
-            .expect("Failed to create HTTP client");
+        let client = mcp_core::http::build_client_or_default(Duration::from_secs(300));
 
         Self {
             client,

--- a/tools/mcp/mcp_core_rust/Cargo.lock
+++ b/tools/mcp/mcp_core_rust/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "clap",
  "futures",
  "mcp-client",
+ "mcp-macros",
  "reqwest",
  "schemars",
  "serde",

--- a/tools/mcp/mcp_core_rust/README.md
+++ b/tools/mcp/mcp_core_rust/README.md
@@ -97,12 +97,41 @@ Rules the macro applies:
 - `#[mcp(default = ...)]` makes a parameter optional and supplies the default;
   the literal keeps its JSON type (`default = 1` is an integer, `default = "x"`
   a string).
+- `#[mcp(state)]` injects a parameter from the tool's own fields instead of the
+  JSON arguments (see below).
 - The function returns `Result<T, E>` where `T: Serialize` and `E: Display`.
   `Ok(value)` is serialized into the tool result; `Err(e)` becomes an
   `isError` tool result carrying `e.to_string()`.
 
+#### Stateful tools with `#[mcp(state)]`
+
+Most real tools need shared state — a store, an HTTP client, a job registry.
+Mark those parameters `#[mcp(state)]`: they are excluded from the input schema
+and instead become struct fields populated by a generated `new(...)`
+constructor (state parameters, in declaration order). State types must be
+`Clone` (typically an `Arc<...>`).
+
+```rust
+#[mcp_tool(description = "Add an amount to a shared counter")]
+async fn add(
+    #[mcp(state)]
+    counter: std::sync::Arc<std::sync::atomic::AtomicI64>,
+    #[mcp(description = "Amount to add")]
+    amount: i64,
+) -> Result<i64, anyhow::Error> {
+    use std::sync::atomic::Ordering;
+    Ok(counter.fetch_add(amount, Ordering::SeqCst) + amount)
+}
+// Generates `AddTool { counter: ... }` with `AddTool::new(counter)`.
+// Register with: `.tool(AddTool::new(counter.clone()))`
+```
+
+With no `#[mcp(state)]` parameters the macro keeps the ergonomic unit struct
+(`EchoTool`); with state it generates the fielded struct plus `new(...)`.
+
 See `crates/mcp-core/tests/mcp_tool_macro.rs` for the executable reference,
-including the schema/required-field and error-path assertions.
+including the schema/required-field, error-path, and state-injection
+assertions.
 
 ### Create a Server
 

--- a/tools/mcp/mcp_core_rust/README.md
+++ b/tools/mcp/mcp_core_rust/README.md
@@ -197,6 +197,23 @@ cargo test
 cargo test -- --nocapture
 ```
 
+The `mcp-testing` crate provides a `TestServer` that registers real tools and
+calls them over the actual `Tool::execute` JSON boundary, plus `MockTool` and
+assertion helpers. Add it as a path dev-dependency to exercise a server's
+tools (including error paths) without standing up HTTP:
+
+```rust
+use mcp_testing::{TestServer, assertions};
+use serde_json::json;
+
+let server = TestServer::new().with_tool(MyTool { /* shared state */ });
+let result = server.call_tool("my_tool", json!({ "field": "value" })).await.unwrap();
+assertions::assert_success(&result);
+```
+
+See `mcp_sprite_sheet`'s `execute_path_tests` for a worked example that drives
+a multi-tool workflow over a shared store.
+
 ## Project Structure
 
 ```
@@ -241,6 +258,25 @@ tool error (`isError: true`) instead of unwinding the connection task or
 crashing the server. The server stays available for subsequent requests. This
 is a safety net, not a license to panic: prefer `#[mcp_tool]` or explicit
 `InvalidParameters` errors so failures are typed rather than caught.
+
+## Shared HTTP client
+
+Servers that call an upstream HTTP service should build their `reqwest::Client`
+via `mcp_core::http` instead of hand-rolling a builder. Both helpers apply a
+shared connect timeout (`DEFAULT_CONNECT_TIMEOUT`, 10s) on top of the caller's
+total request timeout, so a dead host fails fast:
+
+```rust
+use std::time::Duration;
+use mcp_core::http;
+
+// Infallible: never panics; falls back to a default client if the (rare)
+// builder error occurs, so the server can still start. Use in `new() -> Self`.
+let client = http::build_client_or_default(Duration::from_secs(30));
+
+// Fallible: propagate the builder error where you have a `Result` to return.
+let client = http::build_client(Duration::from_secs(30))?;
+```
 
 ## Development Status
 

--- a/tools/mcp/mcp_core_rust/README.md
+++ b/tools/mcp/mcp_core_rust/README.md
@@ -17,7 +17,7 @@ This workspace provides the core infrastructure for building MCP servers in Rust
 | Crate | Description |
 |-------|-------------|
 | `mcp-core` | Core server library with Tool trait, HTTP transport, and JSON-RPC handling |
-| `mcp-macros` | Procedural macros for tool registration (WIP) |
+| `mcp-macros` | `#[mcp_tool]` procedural macro for typed tool definitions |
 | `mcp-client` | REST client for proxy mode |
 | `mcp-testing` | Test utilities and mock tools |
 
@@ -56,6 +56,53 @@ impl Tool for EchoTool {
     }
 }
 ```
+
+### Define a Tool with `#[mcp_tool]` (recommended)
+
+The hand-written `impl Tool` above extracts arguments out of a raw
+`serde_json::Value`. That pattern is easy to get wrong: a `.unwrap()` /
+`["field"]` on missing or wrong-typed input **panics**, and a panic in tool
+execution used to be a latent crash vector. Prefer the `#[mcp_tool]` macro,
+which generates the `Tool` impl from a typed `async fn`: parameters are
+deserialized into their declared Rust types, the JSON schema is derived
+automatically, and a missing/mismatched argument becomes a clean
+`InvalidParameters` error instead of a panic.
+
+```rust
+use mcp_macros::mcp_tool;
+
+#[mcp_tool(description = "Echo the input message a number of times")]
+async fn echo(
+    #[mcp(description = "Message to echo")]
+    message: String,
+    #[mcp(description = "Repeat count", default = 1)]
+    count: i64,
+    #[mcp(description = "Optional suffix")]
+    suffix: Option<String>,
+) -> Result<String, anyhow::Error> {
+    let mut out = message.repeat(count as usize);
+    if let Some(s) = suffix {
+        out.push_str(&s);
+    }
+    Ok(out)
+}
+// Generates a unit struct `EchoTool` implementing `Tool`; register it with
+// `.tool(EchoTool)` exactly like a hand-written tool.
+```
+
+Rules the macro applies:
+
+- A plain parameter (e.g. `message: String`) is **required**.
+- `Option<T>` is **optional** (an absent key deserializes as `None`).
+- `#[mcp(default = ...)]` makes a parameter optional and supplies the default;
+  the literal keeps its JSON type (`default = 1` is an integer, `default = "x"`
+  a string).
+- The function returns `Result<T, E>` where `T: Serialize` and `E: Display`.
+  `Ok(value)` is serialized into the tool result; `Err(e)` becomes an
+  `isError` tool result carrying `e.to_string()`.
+
+See `crates/mcp-core/tests/mcp_tool_macro.rs` for the executable reference,
+including the schema/required-field and error-path assertions.
 
 ### Create a Server
 
@@ -139,7 +186,7 @@ tools/mcp/mcp_core_rust/
 │   │   │   └── transport/  # HTTP transport
 │   │   └── examples/
 │   │       └── echo_server.rs
-│   ├── mcp-macros/         # Proc macros (WIP)
+│   ├── mcp-macros/         # #[mcp_tool] proc macro
 │   ├── mcp-client/         # REST client
 │   └── mcp-testing/        # Test utilities
 └── servers/                # Converted MCP servers (future)
@@ -154,7 +201,17 @@ This library is designed to match the Python `mcp_core` API:
 | `BaseMCPServer` | `MCPServer` |
 | `get_tools()` | `impl Tool` |
 | `run(mode="http")` | `server.run().await` |
-| `@tool_decorator` | `#[mcp_tool]` (future) |
+| `@tool_decorator` | `#[mcp_tool]` |
+
+## Robustness: tool-execution panic boundary
+
+`tools/call` runs each tool inside a `catch_unwind` boundary
+(`transport/handler.rs`). If a tool panics — for example a stray `.unwrap()` on
+a malformed argument — the panic is caught and returned to the client as an MCP
+tool error (`isError: true`) instead of unwinding the connection task or
+crashing the server. The server stays available for subsequent requests. This
+is a safety net, not a license to panic: prefer `#[mcp_tool]` or explicit
+`InvalidParameters` errors so failures are typed rather than caught.
 
 ## Development Status
 
@@ -165,8 +222,9 @@ This library is designed to match the Python `mcp_core` API:
 - [x] Session management
 - [x] Server modes (standalone working)
 - [x] Example server
-- [x] Unit tests (15 passing)
-- [ ] Proc macros for tool registration
+- [x] Unit tests
+- [x] Tool-execution panic boundary (`catch_unwind` in `tools/call`)
+- [x] Proc macros for tool registration (`#[mcp_tool]`)
 
 **Phase 2: Pilot Server**
 - [ ] Port `mcp_reaction_search` to Rust

--- a/tools/mcp/mcp_core_rust/crates/mcp-core/Cargo.toml
+++ b/tools/mcp/mcp_core_rust/crates/mcp-core/Cargo.toml
@@ -30,6 +30,8 @@ mcp-client = { path = "../mcp-client" }
 [dev-dependencies]
 tokio-test = { workspace = true }
 axum-test = { workspace = true }
+# Exercises the #[mcp_tool] macro end-to-end (see tests/mcp_tool_macro.rs).
+mcp-macros = { path = "../mcp-macros" }
 
 [[example]]
 name = "echo_server"

--- a/tools/mcp/mcp_core_rust/crates/mcp-core/src/http.rs
+++ b/tools/mcp/mcp_core_rust/crates/mcp-core/src/http.rs
@@ -1,0 +1,65 @@
+//! Shared HTTP client construction for MCP servers.
+//!
+//! Most servers that talk to an upstream HTTP service hand-roll the same
+//! `reqwest::Client::builder().timeout(..).build().expect(..)` block, each with
+//! a different total timeout and none with a connect timeout. This module
+//! centralizes that so every client gets a consistent connect timeout and the
+//! build failure is surfaced as an error rather than a bespoke `expect` string.
+//!
+//! ```no_run
+//! use std::time::Duration;
+//! use mcp_core::http;
+//!
+//! // Fallible: propagate the (rare) builder error.
+//! let client = http::build_client(Duration::from_secs(30))?;
+//!
+//! // Infallible: never panics; falls back to a default client if the builder
+//! // fails so a server can still start.
+//! let client = http::build_client_or_default(Duration::from_secs(30));
+//! # Ok::<(), reqwest::Error>(())
+//! ```
+
+use std::time::Duration;
+
+/// Default connection-establishment timeout applied to all clients built here.
+///
+/// Bounds the time spent opening a TCP/TLS connection so a dead or unreachable
+/// host fails fast instead of waiting for the (longer) total request timeout.
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Build a [`reqwest::Client`] with a total request `timeout` and the shared
+/// [`DEFAULT_CONNECT_TIMEOUT`].
+///
+/// Returns the builder error instead of panicking; callers that construct
+/// infallibly (e.g. a `new() -> Self`) can use [`build_client_or_default`].
+pub fn build_client(timeout: Duration) -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+        .build()
+}
+
+/// Like [`build_client`] but never fails: if the builder errors (rare, e.g. a
+/// TLS backend that fails to initialize), fall back to [`reqwest::Client::new`]
+/// so the server can still start. The fallback loses the configured timeouts,
+/// which is strictly better than aborting startup.
+pub fn build_client_or_default(timeout: Duration) -> reqwest::Client {
+    build_client(timeout).unwrap_or_else(|_| reqwest::Client::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_client_succeeds_with_typical_timeout() {
+        assert!(build_client(Duration::from_secs(30)).is_ok());
+    }
+
+    #[test]
+    fn build_client_or_default_always_returns_client() {
+        // Should not panic for any reasonable timeout, including zero.
+        let _ = build_client_or_default(Duration::from_secs(0));
+        let _ = build_client_or_default(Duration::from_secs(300));
+    }
+}

--- a/tools/mcp/mcp_core_rust/crates/mcp-core/src/lib.rs
+++ b/tools/mcp/mcp_core_rust/crates/mcp-core/src/lib.rs
@@ -91,6 +91,7 @@
 //! ```
 
 pub mod error;
+pub mod http;
 pub mod jsonrpc;
 pub mod server;
 pub mod session;

--- a/tools/mcp/mcp_core_rust/crates/mcp-core/src/tool.rs
+++ b/tools/mcp/mcp_core_rust/crates/mcp-core/src/tool.rs
@@ -105,7 +105,18 @@ pub struct ToolSchema {
     pub input_schema: Value,
 }
 
-/// A single MCP tool that can be executed
+/// A single MCP tool that can be executed.
+///
+/// # Panic boundary and interior state
+///
+/// `tools/call` runs [`Tool::execute`] inside a `catch_unwind` boundary
+/// (see `transport/handler.rs`), so a panic becomes an `isError` result rather
+/// than crashing the server. One caveat: a panic that unwinds while a
+/// `std::sync::Mutex`/`RwLock` in the tool's state is locked **poisons** that
+/// lock, so every later `.lock()` returns `PoisonError` and the tool degrades
+/// to permanent failure. Prefer poison-free primitives for shared tool state:
+/// `tokio::sync::Mutex`/`RwLock` (used by the servers in this repo) or the
+/// `std::sync::atomic` types.
 #[async_trait]
 pub trait Tool: Send + Sync {
     /// Get the tool's unique name

--- a/tools/mcp/mcp_core_rust/crates/mcp-core/src/transport/handler.rs
+++ b/tools/mcp/mcp_core_rust/crates/mcp-core/src/transport/handler.rs
@@ -1,7 +1,10 @@
 //! Shared MCP protocol handler used by both HTTP and STDIO transports.
 
+use std::panic::AssertUnwindSafe;
+
+use futures::FutureExt;
 use serde_json::{Value, json};
-use tracing::info;
+use tracing::{error, info};
 
 use crate::error::{JsonRpcErrorCode, MCPError};
 use crate::jsonrpc::{
@@ -9,7 +12,18 @@ use crate::jsonrpc::{
     ServerCapabilities, ServerInfo, ToolCallParams, ToolCallResult, ToolInfo, ToolsListResult,
 };
 use crate::session::{ClientInfo, SessionManager};
-use crate::tool::{Content, ToolRegistry};
+use crate::tool::{Content, ToolRegistry, ToolResult};
+
+/// Extract a human-readable message from a caught panic payload.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
 
 /// Shared MCP protocol handler.
 ///
@@ -169,7 +183,29 @@ impl MCPHandler {
             .get(&call_params.name)
             .ok_or_else(|| MCPError::ToolNotFound(call_params.name.clone()))?;
 
-        let result = tool.execute(call_params.arguments).await?;
+        // Execute the tool inside a panic boundary. A buggy tool that panics on
+        // malformed/untrusted arguments must not take down the whole server (or
+        // the connection task); instead the panic is converted into an MCP tool
+        // error result (`isError: true`), which is the spec-recommended way to
+        // surface execution failures so the client/model can recover.
+        let result = match AssertUnwindSafe(tool.execute(call_params.arguments))
+            .catch_unwind()
+            .await
+        {
+            Ok(Ok(result)) => result,
+            Ok(Err(e)) => return Err(e),
+            Err(panic) => {
+                let msg = panic_message(panic.as_ref());
+                error!(
+                    "Tool '{}' panicked during execution: {}",
+                    call_params.name, msg
+                );
+                ToolResult::error(format!(
+                    "Tool '{}' panicked during execution: {}",
+                    call_params.name, msg
+                ))
+            },
+        };
 
         // Convert internal content to JSON-RPC content blocks
         let content: Vec<ContentBlock> = result
@@ -218,9 +254,28 @@ mod tests {
         }
     }
 
+    struct PanicTool;
+
+    #[async_trait]
+    impl crate::tool::Tool for PanicTool {
+        fn name(&self) -> &str {
+            "panic_tool"
+        }
+        fn description(&self) -> &str {
+            "A tool that panics, simulating an unwrap() on malformed input"
+        }
+        fn schema(&self) -> Value {
+            json!({"type": "object", "properties": {}})
+        }
+        async fn execute(&self, _args: Value) -> crate::error::Result<ToolResult> {
+            panic!("boom: simulated unwrap on bad arg");
+        }
+    }
+
     fn make_handler() -> MCPHandler {
         let mut tools = ToolRegistry::new();
         tools.register(TestTool);
+        tools.register(PanicTool);
         MCPHandler::new("test-server", "1.0.0", tools)
     }
 
@@ -241,8 +296,39 @@ mod tests {
         let resp = handler.process_request(&req, &None).await.unwrap();
         let result = resp.result.unwrap();
         let tools = result["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0]["name"], "test_tool");
+        assert_eq!(tools.len(), 2);
+        assert!(tools.iter().any(|t| t["name"] == "test_tool"));
+    }
+
+    #[tokio::test]
+    async fn test_tool_panic_is_caught() {
+        // A panicking tool must not crash the handler; it should be reported as
+        // a graceful tool error result (isError: true) with a successful
+        // JSON-RPC envelope.
+        let handler = make_handler();
+        let req = JsonRpcRequest::new(
+            "tools/call",
+            json!({"name": "panic_tool", "arguments": {}}),
+            1,
+        );
+        let resp = handler.process_request(&req, &None).await.unwrap();
+        assert!(
+            resp.error.is_none(),
+            "panic should not surface as a protocol error"
+        );
+        let result = resp.result.expect("expected a successful JSON-RPC result");
+        assert_eq!(result["isError"], true);
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("panicked"), "got: {text}");
+        assert!(
+            text.contains("boom"),
+            "panic message should be preserved: {text}"
+        );
+
+        // The handler must still serve subsequent requests after a panic.
+        let req2 = JsonRpcRequest::new("ping", json!({}), 2);
+        let resp2 = handler.process_request(&req2, &None).await.unwrap();
+        assert_eq!(resp2.result.unwrap()["pong"], true);
     }
 
     #[tokio::test]

--- a/tools/mcp/mcp_core_rust/crates/mcp-core/tests/mcp_tool_macro.rs
+++ b/tools/mcp/mcp_core_rust/crates/mcp-core/tests/mcp_tool_macro.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
+
 use mcp_core::tool::{Content, Tool};
 use mcp_macros::mcp_tool;
 use serde_json::json;
@@ -68,4 +71,42 @@ async fn wrong_type_is_clean_error_not_panic() {
         .await
         .unwrap_err();
     assert!(err.to_string().contains("Invalid parameter 'count'"));
+}
+
+// --- Stateful tools (#[mcp(state)]) -------------------------------------
+
+/// A shared counter standing in for real injected state (a store, HTTP client,
+/// job registry, ...). State types must be `Clone`.
+type Counter = Arc<AtomicI64>;
+
+#[mcp_tool(description = "Add an amount to a shared counter and return the total")]
+async fn add(
+    #[mcp(state)] counter: Counter,
+    #[mcp(description = "Amount to add")] amount: i64,
+) -> Result<i64, anyhow::Error> {
+    Ok(counter.fetch_add(amount, Ordering::SeqCst) + amount)
+}
+
+#[tokio::test]
+async fn state_param_is_excluded_from_schema() {
+    let counter: Counter = Arc::new(AtomicI64::new(0));
+    let tool = AddTool::new(counter);
+    let schema = tool.schema();
+    // `counter` is injected state, so only `amount` is in the schema.
+    assert!(schema["properties"].get("counter").is_none());
+    assert!(schema["properties"].get("amount").is_some());
+    assert_eq!(schema["required"].as_array().unwrap(), &[json!("amount")]);
+}
+
+#[tokio::test]
+async fn state_is_injected_and_shared_across_calls() {
+    let counter: Counter = Arc::new(AtomicI64::new(0));
+    let tool = AddTool::new(Arc::clone(&counter));
+
+    let r1 = tool.execute(json!({"amount": 3})).await.unwrap();
+    assert!(result_text(&r1).contains('3'));
+    let r2 = tool.execute(json!({"amount": 4})).await.unwrap();
+    assert!(result_text(&r2).contains('7'));
+    // The injected state persisted across both calls.
+    assert_eq!(counter.load(Ordering::SeqCst), 7);
 }

--- a/tools/mcp/mcp_core_rust/crates/mcp-core/tests/mcp_tool_macro.rs
+++ b/tools/mcp/mcp_core_rust/crates/mcp-core/tests/mcp_tool_macro.rs
@@ -18,6 +18,13 @@ async fn echo(
     Ok(out)
 }
 
+#[mcp_tool(description = "Return the offset, defaulting to a negative value")]
+async fn offset(
+    #[mcp(description = "Offset to return", default = -1)] value: i64,
+) -> Result<i64, anyhow::Error> {
+    Ok(value)
+}
+
 fn result_text(r: &mcp_core::tool::ToolResult) -> String {
     match &r.content[0] {
         Content::Text { text } => text.clone(),
@@ -71,6 +78,15 @@ async fn wrong_type_is_clean_error_not_panic() {
         .await
         .unwrap_err();
     assert!(err.to_string().contains("Invalid parameter 'count'"));
+}
+
+#[tokio::test]
+async fn negative_literal_default_is_applied() {
+    // `default = -1` parses as a unary expression, not a `Lit`; the macro must
+    // accept it and preserve the negative integer JSON type.
+    let r = OffsetTool.execute(json!({})).await.unwrap();
+    assert!(!r.is_error);
+    assert!(result_text(&r).contains("-1"));
 }
 
 // --- Stateful tools (#[mcp(state)]) -------------------------------------

--- a/tools/mcp/mcp_core_rust/crates/mcp-core/tests/mcp_tool_macro.rs
+++ b/tools/mcp/mcp_core_rust/crates/mcp-core/tests/mcp_tool_macro.rs
@@ -1,0 +1,71 @@
+use mcp_core::tool::{Content, Tool};
+use mcp_macros::mcp_tool;
+use serde_json::json;
+
+#[mcp_tool(description = "Echo the input message a number of times")]
+async fn echo(
+    #[mcp(description = "Message to echo")] message: String,
+    #[mcp(description = "Repeat count", default = 1)] count: i64,
+    #[mcp(description = "Optional suffix")] suffix: Option<String>,
+) -> Result<String, anyhow::Error> {
+    let mut out = message.repeat(count as usize);
+    if let Some(s) = suffix {
+        out.push_str(&s);
+    }
+    Ok(out)
+}
+
+fn result_text(r: &mcp_core::tool::ToolResult) -> String {
+    match &r.content[0] {
+        Content::Text { text } => text.clone(),
+        _ => panic!("expected text content"),
+    }
+}
+
+#[tokio::test]
+async fn schema_marks_required_and_optional_correctly() {
+    let schema = EchoTool.schema();
+    let required = schema["required"].as_array().unwrap();
+    // `message` is required; `count` has a default and `suffix` is Option -> optional.
+    assert_eq!(required.len(), 1);
+    assert_eq!(required[0], "message");
+    assert_eq!(schema["properties"]["count"]["type"], "integer");
+    assert_eq!(schema["properties"]["suffix"]["type"], "string");
+}
+
+#[tokio::test]
+async fn uses_default_when_arg_absent() {
+    let r = EchoTool.execute(json!({"message": "ab"})).await.unwrap();
+    assert!(!r.is_error);
+    // default count = 1, no suffix -> "ab" (JSON-encoded string)
+    assert!(result_text(&r).contains("ab"));
+}
+
+#[tokio::test]
+async fn deserializes_typed_args() {
+    let r = EchoTool
+        .execute(json!({"message": "x", "count": 3, "suffix": "!"}))
+        .await
+        .unwrap();
+    assert!(result_text(&r).contains("xxx!"));
+}
+
+#[tokio::test]
+async fn missing_required_arg_is_clean_error() {
+    let err = EchoTool.execute(json!({})).await.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Missing required parameter: message")
+    );
+}
+
+#[tokio::test]
+async fn wrong_type_is_clean_error_not_panic() {
+    // count should be an integer; passing a string must yield InvalidParameters,
+    // not a panic.
+    let err = EchoTool
+        .execute(json!({"message": "x", "count": "not a number"}))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("Invalid parameter 'count'"));
+}

--- a/tools/mcp/mcp_core_rust/crates/mcp-macros/src/lib.rs
+++ b/tools/mcp/mcp_core_rust/crates/mcp-macros/src/lib.rs
@@ -112,7 +112,9 @@ struct ParamInfo {
     name: Ident,
     ty: Type,
     description: Option<String>,
-    default: Option<String>,
+    /// Default value literal, preserved as a `Lit` so its JSON type (integer,
+    /// string, bool, ...) survives into the generated schema and extraction.
+    default: Option<Lit>,
     is_optional: bool,
 }
 
@@ -133,6 +135,7 @@ fn generate_tool(attrs: ToolAttrs, func: ItemFn) -> syn::Result<TokenStream2> {
 
     // Generate the function call
     let param_names: Vec<_> = params.iter().map(|p| &p.name).collect();
+    let param_types: Vec<_> = params.iter().map(|p| &p.ty).collect();
 
     // Keep the original function but make it a method
     let func_body = &func.block;
@@ -144,11 +147,11 @@ fn generate_tool(attrs: ToolAttrs, func: ItemFn) -> syn::Result<TokenStream2> {
     };
 
     Ok(quote! {
-        /// Generated tool struct for #func_name
+        #[doc = concat!("Generated MCP tool for `", stringify!(#func_name), "`.")]
         pub struct #tool_struct_name;
 
         impl #tool_struct_name {
-            async fn execute_impl(#(#param_names: _,)*) -> #output_type
+            async fn execute_impl(#(#param_names: #param_types,)*) -> #output_type
             #func_body
         }
 
@@ -207,7 +210,7 @@ fn parse_params(func: &ItemFn) -> syn::Result<Vec<ParamInfo>> {
     Ok(params)
 }
 
-fn parse_param_attrs(attrs: &[Attribute]) -> (Option<String>, Option<String>) {
+fn parse_param_attrs(attrs: &[Attribute]) -> (Option<String>, Option<Lit>) {
     let mut description = None;
     let mut default = None;
 
@@ -218,14 +221,9 @@ fn parse_param_attrs(attrs: &[Attribute]) -> (Option<String>, Option<String>) {
                     let value: syn::LitStr = meta.value()?.parse()?;
                     description = Some(value.value());
                 } else if meta.path.is_ident("default") {
-                    let value: syn::Lit = meta.value()?.parse()?;
-                    default = Some(match value {
-                        Lit::Str(s) => s.value(),
-                        Lit::Int(i) => i.to_string(),
-                        Lit::Float(f) => f.to_string(),
-                        Lit::Bool(b) => b.value.to_string(),
-                        _ => String::new(),
-                    });
+                    // Preserve the literal so the generated `json!(...)` keeps the
+                    // correct JSON type (e.g. `1` -> integer, not the string "1").
+                    default = Some(meta.value()?.parse::<Lit>()?);
                 }
                 Ok(())
             });
@@ -281,25 +279,41 @@ fn generate_arg_extraction(params: &[ParamInfo]) -> TokenStream2 {
         .iter()
         .map(|p| {
             let name = &p.name;
+            let ty = &p.ty;
             let name_str = name.to_string();
 
+            // Each parameter is bound to its *declared* type by deserializing the
+            // corresponding JSON value via serde. A type mismatch or a missing
+            // required parameter becomes a clean `InvalidParameters` error rather
+            // than a panic, which is the whole point of the typed macro path.
             if p.is_optional {
+                // `Option<T>`: an absent key deserializes from `null` -> `None`.
                 quote! {
-                    let #name = args.get(#name_str).cloned();
+                    let #name: #ty = serde_json::from_value(
+                        args.get(#name_str).cloned().unwrap_or(serde_json::Value::Null)
+                    ).map_err(|e| mcp_core::error::MCPError::InvalidParameters(
+                        format!("Invalid parameter '{}': {}", #name_str, e)
+                    ))?;
                 }
             } else if let Some(default) = &p.default {
                 quote! {
-                    let #name = args.get(#name_str)
-                        .cloned()
-                        .unwrap_or_else(|| serde_json::json!(#default));
+                    let #name: #ty = serde_json::from_value(
+                        args.get(#name_str).cloned().unwrap_or_else(|| serde_json::json!(#default))
+                    ).map_err(|e| mcp_core::error::MCPError::InvalidParameters(
+                        format!("Invalid parameter '{}': {}", #name_str, e)
+                    ))?;
                 }
             } else {
                 quote! {
-                    let #name = args.get(#name_str)
-                        .cloned()
-                        .ok_or_else(|| mcp_core::error::MCPError::InvalidParameters(
-                            format!("Missing required parameter: {}", #name_str)
-                        ))?;
+                    let #name: #ty = serde_json::from_value(
+                        args.get(#name_str).cloned().ok_or_else(|| {
+                            mcp_core::error::MCPError::InvalidParameters(
+                                format!("Missing required parameter: {}", #name_str)
+                            )
+                        })?
+                    ).map_err(|e| mcp_core::error::MCPError::InvalidParameters(
+                        format!("Invalid parameter '{}': {}", #name_str, e)
+                    ))?;
                 }
             }
         })

--- a/tools/mcp/mcp_core_rust/crates/mcp-macros/src/lib.rs
+++ b/tools/mcp/mcp_core_rust/crates/mcp-macros/src/lib.rs
@@ -38,8 +38,9 @@ use syn::{
 ///
 /// Parameters can have `#[mcp(...)]` attributes:
 /// - `description`: Parameter description
-/// - `default`: Default value (makes parameter optional); the literal keeps its
-///   JSON type (`default = 1` is an integer, `default = "x"` a string)
+/// - `default`: Default value (makes parameter optional); the value keeps its
+///   JSON type (`default = 1` is an integer, `default = "x"` a string,
+///   `default = -1` a negative integer)
 /// - `state`: Inject this parameter from the generated struct's fields instead
 ///   of deserializing it from the JSON arguments. State parameters are excluded
 ///   from the input schema and must be `Clone`. When any parameter is marked
@@ -125,9 +126,11 @@ struct ParamInfo {
     name: Ident,
     ty: Type,
     description: Option<String>,
-    /// Default value literal, preserved as a `Lit` so its JSON type (integer,
+    /// Default value, preserved as a `syn::Expr` so its JSON type (integer,
     /// string, bool, ...) survives into the generated schema and extraction.
-    default: Option<Lit>,
+    /// Using `Expr` rather than `Lit` also accepts negated literals such as
+    /// `#[mcp(default = -1)]`, which parse as a unary expression, not a `Lit`.
+    default: Option<syn::Expr>,
     is_optional: bool,
     /// Marked `#[mcp(state)]`: injected from the generated struct's fields
     /// (e.g. a shared store or HTTP client) rather than deserialized from the
@@ -271,7 +274,7 @@ fn parse_params(func: &ItemFn) -> syn::Result<Vec<ParamInfo>> {
     Ok(params)
 }
 
-fn parse_param_attrs(attrs: &[Attribute]) -> (Option<String>, Option<Lit>, bool) {
+fn parse_param_attrs(attrs: &[Attribute]) -> (Option<String>, Option<syn::Expr>, bool) {
     let mut description = None;
     let mut default = None;
     let mut is_state = false;
@@ -283,9 +286,11 @@ fn parse_param_attrs(attrs: &[Attribute]) -> (Option<String>, Option<Lit>, bool)
                     let value: syn::LitStr = meta.value()?.parse()?;
                     description = Some(value.value());
                 } else if meta.path.is_ident("default") {
-                    // Preserve the literal so the generated `json!(...)` keeps the
+                    // Preserve the expression so the generated `json!(...)` keeps the
                     // correct JSON type (e.g. `1` -> integer, not the string "1").
-                    default = Some(meta.value()?.parse::<Lit>()?);
+                    // Parsing as `Expr` (not `Lit`) also accepts negated literals
+                    // like `default = -1`, which are unary expressions.
+                    default = Some(meta.value()?.parse::<syn::Expr>()?);
                 } else if meta.path.is_ident("state") {
                     // Flag form: `#[mcp(state)]` (no value).
                     is_state = true;

--- a/tools/mcp/mcp_core_rust/crates/mcp-macros/src/lib.rs
+++ b/tools/mcp/mcp_core_rust/crates/mcp-macros/src/lib.rs
@@ -38,20 +38,33 @@ use syn::{
 ///
 /// Parameters can have `#[mcp(...)]` attributes:
 /// - `description`: Parameter description
-/// - `default`: Default value (makes parameter optional)
+/// - `default`: Default value (makes parameter optional); the literal keeps its
+///   JSON type (`default = 1` is an integer, `default = "x"` a string)
+/// - `state`: Inject this parameter from the generated struct's fields instead
+///   of deserializing it from the JSON arguments. State parameters are excluded
+///   from the input schema and must be `Clone`. When any parameter is marked
+///   `state`, the macro generates a fielded struct with a `new(...)`
+///   constructor (in declaration order) instead of a unit struct.
+///
+/// Plain parameters are required; `Option<T>` parameters are optional. Missing
+/// or wrong-typed arguments produce an `InvalidParameters` error rather than a
+/// panic.
 ///
 /// # Example
 ///
 /// ```rust,ignore
 /// #[mcp_tool(description = "Search for items")]
 /// async fn search(
+///     #[mcp(state)]
+///     store: Arc<Store>,                // injected, not from JSON
 ///     #[mcp(description = "Search query")]
 ///     query: String,
 ///     #[mcp(description = "Max results", default = 10)]
 ///     limit: Option<i32>,
-/// ) -> Result<Vec<Item>> {
-///     // Implementation
+/// ) -> Result<Vec<Item>, anyhow::Error> {
+///     // Implementation; `store` is `self.store.clone()`
 /// }
+/// // Register with: `.tool(SearchTool::new(store.clone()))`
 /// ```
 #[proc_macro_attribute]
 pub fn mcp_tool(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -116,6 +129,10 @@ struct ParamInfo {
     /// string, bool, ...) survives into the generated schema and extraction.
     default: Option<Lit>,
     is_optional: bool,
+    /// Marked `#[mcp(state)]`: injected from the generated struct's fields
+    /// (e.g. a shared store or HTTP client) rather than deserialized from the
+    /// JSON arguments. Such params are excluded from the schema.
+    is_state: bool,
 }
 
 fn generate_tool(attrs: ToolAttrs, func: ItemFn) -> syn::Result<TokenStream2> {
@@ -133,9 +150,30 @@ fn generate_tool(attrs: ToolAttrs, func: ItemFn) -> syn::Result<TokenStream2> {
     // Generate argument extraction
     let arg_extraction = generate_arg_extraction(&params);
 
-    // Generate the function call
+    // execute_impl keeps every parameter (state + args) in the original order.
     let param_names: Vec<_> = params.iter().map(|p| &p.name).collect();
     let param_types: Vec<_> = params.iter().map(|p| &p.ty).collect();
+
+    // State parameters (`#[mcp(state)]`) become struct fields populated by a
+    // generated `new(...)` constructor; everything else is deserialized from the
+    // JSON arguments at call time.
+    let state_params: Vec<&ParamInfo> = params.iter().filter(|p| p.is_state).collect();
+    let state_names: Vec<_> = state_params.iter().map(|p| &p.name).collect();
+    let state_types: Vec<_> = state_params.iter().map(|p| &p.ty).collect();
+
+    // Build the execute_impl call arguments in declaration order: state values
+    // are cloned out of `self`, arg values come from the deserialized locals.
+    let call_args: Vec<TokenStream2> = params
+        .iter()
+        .map(|p| {
+            let name = &p.name;
+            if p.is_state {
+                quote! { self.#name.clone() }
+            } else {
+                quote! { #name }
+            }
+        })
+        .collect();
 
     // Keep the original function but make it a method
     let func_body = &func.block;
@@ -146,9 +184,31 @@ fn generate_tool(attrs: ToolAttrs, func: ItemFn) -> syn::Result<TokenStream2> {
         ReturnType::Type(_, ty) => quote! { #ty },
     };
 
+    // With no state, keep the ergonomic unit struct (`MyTool`); with state,
+    // generate a fielded struct plus a `new(...)` constructor.
+    let struct_def = if state_params.is_empty() {
+        quote! {
+            #[doc = concat!("Generated MCP tool for `", stringify!(#func_name), "`.")]
+            pub struct #tool_struct_name;
+        }
+    } else {
+        quote! {
+            #[doc = concat!("Generated MCP tool for `", stringify!(#func_name), "`.")]
+            pub struct #tool_struct_name {
+                #(#state_names: #state_types,)*
+            }
+
+            impl #tool_struct_name {
+                #[doc = "Construct the tool with its injected state."]
+                pub fn new(#(#state_names: #state_types,)*) -> Self {
+                    Self { #(#state_names,)* }
+                }
+            }
+        }
+    };
+
     Ok(quote! {
-        #[doc = concat!("Generated MCP tool for `", stringify!(#func_name), "`.")]
-        pub struct #tool_struct_name;
+        #struct_def
 
         impl #tool_struct_name {
             async fn execute_impl(#(#param_names: #param_types,)*) -> #output_type
@@ -172,7 +232,7 @@ fn generate_tool(attrs: ToolAttrs, func: ItemFn) -> syn::Result<TokenStream2> {
             async fn execute(&self, args: serde_json::Value) -> mcp_core::error::Result<mcp_core::tool::ToolResult> {
                 #arg_extraction
 
-                match Self::execute_impl(#(#param_names,)*).await {
+                match Self::execute_impl(#(#call_args,)*).await {
                     Ok(result) => mcp_core::tool::ToolResult::json(&result),
                     Err(e) => Ok(mcp_core::tool::ToolResult::error(e.to_string())),
                 }
@@ -195,7 +255,7 @@ fn parse_params(func: &ItemFn) -> syn::Result<Vec<ParamInfo>> {
             let is_optional = is_option_type(&ty);
 
             // Parse #[mcp(...)] attributes
-            let (description, default) = parse_param_attrs(&pat_type.attrs);
+            let (description, default, is_state) = parse_param_attrs(&pat_type.attrs);
 
             params.push(ParamInfo {
                 name,
@@ -203,6 +263,7 @@ fn parse_params(func: &ItemFn) -> syn::Result<Vec<ParamInfo>> {
                 description,
                 default,
                 is_optional,
+                is_state,
             });
         }
     }
@@ -210,9 +271,10 @@ fn parse_params(func: &ItemFn) -> syn::Result<Vec<ParamInfo>> {
     Ok(params)
 }
 
-fn parse_param_attrs(attrs: &[Attribute]) -> (Option<String>, Option<Lit>) {
+fn parse_param_attrs(attrs: &[Attribute]) -> (Option<String>, Option<Lit>, bool) {
     let mut description = None;
     let mut default = None;
+    let mut is_state = false;
 
     for attr in attrs {
         if attr.path().is_ident("mcp") {
@@ -224,13 +286,16 @@ fn parse_param_attrs(attrs: &[Attribute]) -> (Option<String>, Option<Lit>) {
                     // Preserve the literal so the generated `json!(...)` keeps the
                     // correct JSON type (e.g. `1` -> integer, not the string "1").
                     default = Some(meta.value()?.parse::<Lit>()?);
+                } else if meta.path.is_ident("state") {
+                    // Flag form: `#[mcp(state)]` (no value).
+                    is_state = true;
                 }
                 Ok(())
             });
         }
     }
 
-    (description, default)
+    (description, default, is_state)
 }
 
 fn is_option_type(ty: &Type) -> bool {
@@ -247,6 +312,9 @@ fn generate_schema(params: &[ParamInfo]) -> TokenStream2 {
     let mut required = Vec::new();
 
     for param in params {
+        if param.is_state {
+            continue;
+        }
         let name = param.name.to_string();
         let description = param.description.as_deref().unwrap_or("");
         let json_type = rust_type_to_json_type(&param.ty);
@@ -277,6 +345,7 @@ fn generate_schema(params: &[ParamInfo]) -> TokenStream2 {
 fn generate_arg_extraction(params: &[ParamInfo]) -> TokenStream2 {
     let extractions: Vec<_> = params
         .iter()
+        .filter(|p| !p.is_state)
         .map(|p| {
             let name = &p.name;
             let ty = &p.ty;

--- a/tools/mcp/mcp_elevenlabs_speech/src/client.rs
+++ b/tools/mcp/mcp_elevenlabs_speech/src/client.rs
@@ -24,10 +24,7 @@ pub struct ElevenLabsClient {
 impl ElevenLabsClient {
     /// Create a new ElevenLabs client
     pub fn new(api_key: String, output_dir: Option<PathBuf>) -> Self {
-        let client = Client::builder()
-            .timeout(std::time::Duration::from_secs(60))
-            .build()
-            .expect("Failed to create HTTP client");
+        let client = mcp_core::http::build_client_or_default(std::time::Duration::from_secs(60));
 
         let output_dir = output_dir.unwrap_or_else(|| {
             dirs::home_dir()

--- a/tools/mcp/mcp_gaea2/src/validation.rs
+++ b/tools/mcp/mcp_gaea2/src/validation.rs
@@ -255,9 +255,7 @@ pub fn normalize_connections(connections: Vec<serde_json::Value>) -> Vec<Connect
     let mut normalized = Vec::new();
 
     for conn in connections {
-        let parsed = if conn.is_object() {
-            let obj = conn.as_object().unwrap();
-
+        let parsed = if let Some(obj) = conn.as_object() {
             // Handle various key formats
             let from_node = obj
                 .get("from_node")
@@ -293,10 +291,9 @@ pub fn normalize_connections(connections: Vec<serde_json::Value>) -> Vec<Connect
                 from_port,
                 to_port,
             }
-        } else if conn.is_array() {
+        } else if let Some(arr) = conn.as_array() {
             // Handle array format [from_id, to_id]
-            let arr = conn.as_array().unwrap();
-            let from_node = arr.get(0).and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+            let from_node = arr.first().and_then(|v| v.as_i64()).unwrap_or(0) as i32;
             let to_node = arr.get(1).and_then(|v| v.as_i64()).unwrap_or(0) as i32;
 
             Connection {

--- a/tools/mcp/mcp_meme_generator/src/upload.rs
+++ b/tools/mcp/mcp_meme_generator/src/upload.rs
@@ -41,10 +41,19 @@ impl MemeUploader {
             },
         };
 
-        let part = multipart::Part::bytes(file_bytes)
+        let part = match multipart::Part::bytes(file_bytes)
             .file_name(file_name)
             .mime_str("application/octet-stream")
-            .unwrap();
+        {
+            Ok(part) => part,
+            Err(e) => {
+                return UploadResult {
+                    success: false,
+                    error: Some(format!("Failed to build multipart body: {}", e)),
+                    ..Default::default()
+                };
+            },
+        };
 
         let form = multipart::Form::new().part("file", part);
 
@@ -132,10 +141,19 @@ impl MemeUploader {
             },
         };
 
-        let part = multipart::Part::bytes(file_bytes)
+        let part = match multipart::Part::bytes(file_bytes)
             .file_name(file_name)
             .mime_str("application/octet-stream")
-            .unwrap();
+        {
+            Ok(part) => part,
+            Err(e) => {
+                return UploadResult {
+                    success: false,
+                    error: Some(format!("Failed to build multipart body: {}", e)),
+                    ..Default::default()
+                };
+            },
+        };
 
         let form = multipart::Form::new().part("file", part);
 
@@ -261,10 +279,19 @@ impl MemeUploader {
             },
         };
 
-        let part = multipart::Part::bytes(file_bytes)
+        let part = match multipart::Part::bytes(file_bytes)
             .file_name(file_name)
             .mime_str("application/octet-stream")
-            .unwrap();
+        {
+            Ok(part) => part,
+            Err(e) => {
+                return UploadResult {
+                    success: false,
+                    error: Some(format!("Failed to build multipart body: {}", e)),
+                    ..Default::default()
+                };
+            },
+        };
 
         let form = multipart::Form::new().part("file", part);
 

--- a/tools/mcp/mcp_meme_generator/src/upload.rs
+++ b/tools/mcp/mcp_meme_generator/src/upload.rs
@@ -8,6 +8,18 @@ use tracing::{info, warn};
 
 use crate::types::UploadResult;
 
+/// Build the multipart body part shared by every upload backend.
+///
+/// Returns the error message on a (rare) builder failure; call sites wrap it in
+/// an [`UploadResult`]. The MIME type is a fixed `application/octet-stream`
+/// since the hosts sniff content themselves.
+fn build_part(file_bytes: Vec<u8>, file_name: String) -> Result<multipart::Part, String> {
+    multipart::Part::bytes(file_bytes)
+        .file_name(file_name)
+        .mime_str("application/octet-stream")
+        .map_err(|e| format!("Failed to build multipart body: {}", e))
+}
+
 /// Upload a meme to free hosting services
 pub struct MemeUploader;
 
@@ -41,15 +53,12 @@ impl MemeUploader {
             },
         };
 
-        let part = match multipart::Part::bytes(file_bytes)
-            .file_name(file_name)
-            .mime_str("application/octet-stream")
-        {
+        let part = match build_part(file_bytes, file_name) {
             Ok(part) => part,
-            Err(e) => {
+            Err(error) => {
                 return UploadResult {
                     success: false,
-                    error: Some(format!("Failed to build multipart body: {}", e)),
+                    error: Some(error),
                     ..Default::default()
                 };
             },
@@ -141,15 +150,12 @@ impl MemeUploader {
             },
         };
 
-        let part = match multipart::Part::bytes(file_bytes)
-            .file_name(file_name)
-            .mime_str("application/octet-stream")
-        {
+        let part = match build_part(file_bytes, file_name) {
             Ok(part) => part,
-            Err(e) => {
+            Err(error) => {
                 return UploadResult {
                     success: false,
-                    error: Some(format!("Failed to build multipart body: {}", e)),
+                    error: Some(error),
                     ..Default::default()
                 };
             },
@@ -279,15 +285,12 @@ impl MemeUploader {
             },
         };
 
-        let part = match multipart::Part::bytes(file_bytes)
-            .file_name(file_name)
-            .mime_str("application/octet-stream")
-        {
+        let part = match build_part(file_bytes, file_name) {
             Ok(part) => part,
-            Err(e) => {
+            Err(error) => {
                 return UploadResult {
                     success: false,
-                    error: Some(format!("Failed to build multipart body: {}", e)),
+                    error: Some(error),
                     ..Default::default()
                 };
             },

--- a/tools/mcp/mcp_opencode/src/opencode.rs
+++ b/tools/mcp/mcp_opencode/src/opencode.rs
@@ -24,10 +24,8 @@ pub struct OpenCodeIntegration {
 impl OpenCodeIntegration {
     /// Create a new OpenCode integration
     pub fn new(config: OpenCodeConfig) -> Self {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(config.timeout_secs))
-            .build()
-            .expect("Failed to create HTTP client");
+        let client =
+            mcp_core::http::build_client_or_default(Duration::from_secs(config.timeout_secs));
 
         Self {
             config,

--- a/tools/mcp/mcp_reaction_search/src/config.rs
+++ b/tools/mcp/mcp_reaction_search/src/config.rs
@@ -150,10 +150,9 @@ impl ConfigLoader {
     async fn fetch_from_github(&self) -> Result<ReactionConfig, ConfigError> {
         info!("Fetching config from {}", self.config_url);
 
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
-            .build()
-            .map_err(|e| ConfigError::FetchError(format!("Failed to create client: {}", e)))?;
+        let client =
+            mcp_core::http::build_client(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+                .map_err(|e| ConfigError::FetchError(format!("Failed to create client: {}", e)))?;
 
         let response = client
             .get(&self.config_url)

--- a/tools/mcp/mcp_sprite_sheet/Cargo.lock
+++ b/tools/mcp/mcp_sprite_sheet/Cargo.lock
@@ -83,6 +83,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +108,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
 
 [[package]]
 name = "autocfg"
@@ -116,7 +132,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -151,7 +167,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -161,6 +177,36 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-test"
+version = "16.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e3a443d2608936a02a222da7b746eb412fede7225b3030b64fe9be99eab8dc"
+dependencies = [
+ "anyhow",
+ "assert-json-diff",
+ "auto-future",
+ "axum",
+ "bytes",
+ "bytesize",
+ "cookie",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower",
+ "url",
 ]
 
 [[package]]
@@ -213,6 +259,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
 name = "cc"
@@ -297,6 +349,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +417,21 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -618,7 +695,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -649,6 +726,17 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -664,7 +752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -675,7 +763,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -703,7 +791,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -721,7 +809,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -757,7 +845,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -1091,6 +1179,7 @@ dependencies = [
  "clap",
  "image",
  "mcp-core",
+ "mcp-testing",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1099,6 +1188,19 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "mcp-testing"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum-test",
+ "mcp-core",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1112,6 +1214,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1169,6 +1281,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1305,12 +1423,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -1426,7 +1560,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -1456,6 +1590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "reserve-port"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1610,22 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b748410c0afdef2ebbe3685a6a862e2ee937127cdaae623336a459451c8d57"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "mime",
+ "mime_guess",
+ "rand",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1869,6 +2028,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,7 +2188,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "iri-string",
  "pin-project-lite",
@@ -2097,7 +2287,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand",
@@ -2111,6 +2301,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -2577,6 +2773,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/tools/mcp/mcp_sprite_sheet/Cargo.toml
+++ b/tools/mcp/mcp_sprite_sheet/Cargo.toml
@@ -48,6 +48,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 tokio-test = "0.4"
+mcp-testing = { path = "../mcp_core_rust/crates/mcp-testing" }
 
 [profile.release]
 lto = true

--- a/tools/mcp/mcp_sprite_sheet/src/server.rs
+++ b/tools/mcp/mcp_sprite_sheet/src/server.rs
@@ -114,3 +114,148 @@ mod tests {
         }
     }
 }
+
+/// Execute-path tests driven through the shared `mcp-testing` harness.
+///
+/// Unlike the `engine` unit tests, these exercise the real `Tool::execute`
+/// JSON boundary (argument parsing -> engine call -> `ToolResult`) for several
+/// tools that share one project store, plus the error paths for malformed or
+/// inconsistent arguments.
+#[cfg(test)]
+mod execute_path_tests {
+    use crate::engine;
+    use crate::tools;
+    use mcp_core::tool::{Content, ToolResult};
+    use mcp_testing::{TestServer, assertions};
+    use serde_json::json;
+
+    /// Build a TestServer wired with several real tools sharing one store.
+    fn server() -> TestServer {
+        let store = engine::new_store();
+        TestServer::new()
+            .with_tool(tools::project::CreateProjectTool {
+                store: store.clone(),
+            })
+            .with_tool(tools::project::ProjectStatusTool {
+                store: store.clone(),
+            })
+            .with_tool(tools::layer::AddLayerTool {
+                store: store.clone(),
+            })
+            .with_tool(tools::draw::SetPixelsTool { store })
+    }
+
+    /// Collect the text content of a tool result as a single string.
+    fn result_text(result: &ToolResult) -> String {
+        result
+            .content
+            .iter()
+            .filter_map(|c| match c {
+                Content::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn full_create_layer_draw_status_workflow() {
+        let server = server();
+
+        // Create a project.
+        let res = server
+            .call_tool(
+                "sprite_create_project",
+                json!({ "name": "hero", "width": 32, "height": 32 }),
+            )
+            .await
+            .expect("create_project should succeed");
+        assertions::assert_success(&res);
+        assertions::assert_text_contains(&res, "hero");
+
+        // Add a layer and pull the generated layer_id out of the result JSON.
+        let res = server
+            .call_tool(
+                "sprite_add_layer",
+                json!({ "name": "hero", "layer_name": "base" }),
+            )
+            .await
+            .expect("add_layer should succeed");
+        assertions::assert_success(&res);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&result_text(&res)).expect("layer result is JSON");
+        let layer_id = parsed["layer_id"]
+            .as_str()
+            .expect("layer_id present")
+            .to_string();
+
+        // Draw pixels onto the layer.
+        let res = server
+            .call_tool(
+                "sprite_set_pixels",
+                json!({
+                    "name": "hero",
+                    "layer_id": layer_id,
+                    "pixels": [
+                        { "x": 0, "y": 0, "color_index": 1 },
+                        { "x": 1, "y": 1, "color_index": 2 }
+                    ]
+                }),
+            )
+            .await
+            .expect("set_pixels should succeed");
+        assertions::assert_success(&res);
+        assertions::assert_text_contains(&res, "\"pixels_set\": 2");
+
+        // Status reflects the layer and the drawn pixels.
+        let res = server
+            .call_tool("sprite_project_status", json!({ "name": "hero" }))
+            .await
+            .expect("status should succeed");
+        assertions::assert_success(&res);
+        assertions::assert_text_contains(&res, "\"layers\": 1");
+        assertions::assert_text_contains(&res, "\"total_pixels\": 2");
+    }
+
+    #[tokio::test]
+    async fn missing_required_arg_is_error_not_panic() {
+        let server = server();
+        // 'name' is required; omit it.
+        let err = server
+            .call_tool(
+                "sprite_create_project",
+                json!({ "width": 16, "height": 16 }),
+            )
+            .await
+            .expect_err("missing 'name' should be an error");
+        assert!(
+            err.contains("name"),
+            "error should mention the field: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn operating_on_unknown_project_is_error() {
+        let server = server();
+        let err = server
+            .call_tool(
+                "sprite_add_layer",
+                json!({ "name": "does_not_exist", "layer_name": "base" }),
+            )
+            .await
+            .expect_err("adding a layer to an unknown project should error");
+        assert!(
+            err.contains("not found"),
+            "error should explain the project is missing: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_name_is_error() {
+        let server = server();
+        let err = server
+            .call_tool("sprite_does_not_exist", json!({}))
+            .await
+            .expect_err("calling an unregistered tool should error");
+        assert!(err.contains("Tool not found"), "unexpected error: {err}");
+    }
+}

--- a/tools/mcp/mcp_video_editor/README.md
+++ b/tools/mcp/mcp_video_editor/README.md
@@ -98,6 +98,7 @@ curl -X POST http://localhost:8019/mcp/execute \
 | `SILENCE_THRESHOLD` | `2.0` | Minimum silence duration to detect |
 | `ENABLE_GPU` | `true` | Enable GPU acceleration for encoding |
 | `MAX_PARALLEL_JOBS` | `2` | Maximum concurrent render jobs |
+| `VIDEO_EDITOR_SUBPROCESS_TIMEOUT_SECS` | `1800` | Per-invocation timeout for ffmpeg/ffprobe/whisper subprocesses |
 
 ### Cache Location
 

--- a/tools/mcp/mcp_video_editor/src/audio.rs
+++ b/tools/mcp/mcp_video_editor/src/audio.rs
@@ -3,11 +3,12 @@
 //! Handles audio extraction, transcription via Whisper, and speaker diarization.
 //! All processing is done via external tools (ffmpeg, whisper CLI).
 
+use crate::process::output_with_timeout;
 use crate::types::{
     AudioAnalysis, ServerConfig, Speaker, Transcript, TranscriptSegment,
     TranscriptSegmentWithSpeaker, VolumePoint, Word,
 };
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -58,24 +59,25 @@ impl AudioProcessor {
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("Audio path contains invalid UTF-8"))?;
 
-        let output = Command::new("ffmpeg")
-            .args([
-                "-i",
-                video_path,
-                "-vn", // No video
-                "-acodec",
-                "pcm_s16le", // PCM 16-bit
-                "-ar",
-                "16000", // 16kHz sample rate (good for speech)
-                "-ac",
-                "1",  // Mono
-                "-y", // Overwrite
-                audio_path_str,
-            ])
-            .stderr(Stdio::piped())
-            .output()
-            .await
-            .context("Failed to run ffmpeg")?;
+        let output = output_with_timeout(
+            Command::new("ffmpeg")
+                .args([
+                    "-i",
+                    video_path,
+                    "-vn", // No video
+                    "-acodec",
+                    "pcm_s16le", // PCM 16-bit
+                    "-ar",
+                    "16000", // 16kHz sample rate (good for speech)
+                    "-ac",
+                    "1",  // Mono
+                    "-y", // Overwrite
+                    audio_path_str,
+                ])
+                .stderr(Stdio::piped()),
+            "ffmpeg for audio extraction",
+        )
+        .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -139,11 +141,7 @@ impl AudioProcessor {
         let output_dir = tempfile::tempdir()?;
         cmd.arg("--output_dir").arg(output_dir.path());
 
-        let output = cmd
-            .stderr(Stdio::piped())
-            .output()
-            .await
-            .context("Failed to run whisper")?;
+        let output = output_with_timeout(cmd.stderr(Stdio::piped()), "whisper").await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -273,8 +271,8 @@ impl AudioProcessor {
             .ok_or_else(|| anyhow::anyhow!("Audio path contains invalid UTF-8"))?;
 
         // Use ffprobe to get audio info
-        let probe_output = Command::new("ffprobe")
-            .args([
+        let probe_output = output_with_timeout(
+            Command::new("ffprobe").args([
                 "-v",
                 "error",
                 "-show_entries",
@@ -282,10 +280,10 @@ impl AudioProcessor {
                 "-of",
                 "json",
                 audio_path_str,
-            ])
-            .output()
-            .await
-            .context("Failed to run ffprobe")?;
+            ]),
+            "ffprobe",
+        )
+        .await?;
 
         let duration: f64;
         let sample_rate: u32;
@@ -325,19 +323,21 @@ impl AudioProcessor {
         }
 
         // Use ffmpeg to detect silence
-        let silence_output = Command::new("ffmpeg")
-            .args([
-                "-i",
-                audio_path_str,
-                "-af",
-                "silencedetect=n=-40dB:d=2",
-                "-f",
-                "null",
-                "-",
-            ])
-            .stderr(Stdio::piped())
-            .output()
-            .await?;
+        let silence_output = output_with_timeout(
+            Command::new("ffmpeg")
+                .args([
+                    "-i",
+                    audio_path_str,
+                    "-af",
+                    "silencedetect=n=-40dB:d=2",
+                    "-f",
+                    "null",
+                    "-",
+                ])
+                .stderr(Stdio::piped()),
+            "ffmpeg for silence detection",
+        )
+        .await?;
 
         let silence_segments =
             self.parse_silence_detect(&String::from_utf8_lossy(&silence_output.stderr));

--- a/tools/mcp/mcp_video_editor/src/main.rs
+++ b/tools/mcp/mcp_video_editor/src/main.rs
@@ -13,6 +13,7 @@
 
 mod audio;
 mod jobs;
+mod process;
 mod server;
 mod types;
 mod video;

--- a/tools/mcp/mcp_video_editor/src/process.rs
+++ b/tools/mcp/mcp_video_editor/src/process.rs
@@ -7,6 +7,7 @@
 //! is killed (via `kill_on_drop`) if it overruns.
 
 use std::process::Output;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -19,14 +20,21 @@ use tracing::warn;
 const DEFAULT_TIMEOUT_SECS: u64 = 1800;
 
 /// Resolve the configured subprocess timeout.
+///
+/// Read from the environment once and cached for the process lifetime, so we
+/// neither re-parse on every invocation nor race a concurrent `set_var` on the
+/// global environment.
 fn subprocess_timeout() -> Duration {
-    Duration::from_secs(
-        std::env::var("VIDEO_EDITOR_SUBPROCESS_TIMEOUT_SECS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .filter(|&secs| secs > 0)
-            .unwrap_or(DEFAULT_TIMEOUT_SECS),
-    )
+    static TIMEOUT: OnceLock<Duration> = OnceLock::new();
+    *TIMEOUT.get_or_init(|| {
+        Duration::from_secs(
+            std::env::var("VIDEO_EDITOR_SUBPROCESS_TIMEOUT_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .filter(|&secs| secs > 0)
+                .unwrap_or(DEFAULT_TIMEOUT_SECS),
+        )
+    })
 }
 
 /// Run a command to completion, killing it if it exceeds the timeout.

--- a/tools/mcp/mcp_video_editor/src/process.rs
+++ b/tools/mcp/mcp_video_editor/src/process.rs
@@ -1,0 +1,53 @@
+//! Subprocess execution helpers with a wall-clock timeout.
+//!
+//! All media work shells out to external tools (ffmpeg, ffprobe, whisper). Those
+//! can hang indefinitely on a malformed input or a stuck device, which would
+//! pin the worker task forever. Routing every invocation through
+//! [`output_with_timeout`] bounds the runtime and guarantees the child process
+//! is killed (via `kill_on_drop`) if it overruns.
+
+use std::process::Output;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+use tracing::warn;
+
+/// Default timeout for a media subprocess call. Generous because renders and
+/// transcriptions are legitimately slow; override with
+/// `VIDEO_EDITOR_SUBPROCESS_TIMEOUT_SECS`.
+const DEFAULT_TIMEOUT_SECS: u64 = 1800;
+
+/// Resolve the configured subprocess timeout.
+fn subprocess_timeout() -> Duration {
+    Duration::from_secs(
+        std::env::var("VIDEO_EDITOR_SUBPROCESS_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&secs| secs > 0)
+            .unwrap_or(DEFAULT_TIMEOUT_SECS),
+    )
+}
+
+/// Run a command to completion, killing it if it exceeds the timeout.
+///
+/// `what` is a short human-readable label for the command, used in error
+/// messages (e.g. `"ffmpeg for scene detection"`).
+pub async fn output_with_timeout(cmd: &mut Command, what: &str) -> Result<Output> {
+    // If the timeout future is dropped, the child is killed rather than orphaned.
+    cmd.kill_on_drop(true);
+    let timeout = subprocess_timeout();
+
+    match tokio::time::timeout(timeout, cmd.output()).await {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(e)) => Err(e).with_context(|| format!("Failed to run {what}")),
+        Err(_elapsed) => {
+            warn!(
+                "{} timed out after {}s; process killed",
+                what,
+                timeout.as_secs()
+            );
+            anyhow::bail!("{what} timed out after {}s", timeout.as_secs())
+        },
+    }
+}

--- a/tools/mcp/mcp_video_editor/src/video.rs
+++ b/tools/mcp/mcp_video_editor/src/video.rs
@@ -2,8 +2,9 @@
 //!
 //! Handles video editing, composition, effects, and rendering via ffmpeg.
 
+use crate::process::output_with_timeout;
 use crate::types::{EditDecision, OutputSettings, RenderOptions, ServerConfig};
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tempfile::TempDir;
@@ -28,8 +29,8 @@ impl VideoProcessor {
     /// Get video information using ffprobe
     #[allow(dead_code)]
     pub async fn get_video_info(&self, video_path: &str) -> Result<VideoInfo> {
-        let output = Command::new("ffprobe")
-            .args([
+        let output = output_with_timeout(
+            Command::new("ffprobe").args([
                 "-v",
                 "error",
                 "-show_entries",
@@ -37,10 +38,10 @@ impl VideoProcessor {
                 "-of",
                 "json",
                 video_path,
-            ])
-            .output()
-            .await
-            .context("Failed to run ffprobe")?;
+            ]),
+            "ffprobe",
+        )
+        .await?;
 
         if !output.status.success() {
             anyhow::bail!(
@@ -119,21 +120,22 @@ impl VideoProcessor {
         info!("Detecting scene changes in: {}", video_path);
 
         // Use ffmpeg with scene detection filter
-        let output = Command::new("ffmpeg")
-            .args([
-                "-i",
-                video_path,
-                "-vf",
-                "select='gt(scene,0.3)',metadata=print:file=-",
-                "-f",
-                "null",
-                "-",
-            ])
-            .stderr(Stdio::piped())
-            .stdout(Stdio::piped())
-            .output()
-            .await
-            .context("Failed to run ffmpeg for scene detection")?;
+        let output = output_with_timeout(
+            Command::new("ffmpeg")
+                .args([
+                    "-i",
+                    video_path,
+                    "-vf",
+                    "select='gt(scene,0.3)',metadata=print:file=-",
+                    "-f",
+                    "null",
+                    "-",
+                ])
+                .stderr(Stdio::piped())
+                .stdout(Stdio::piped()),
+            "ffmpeg for scene detection",
+        )
+        .await?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -166,27 +168,8 @@ impl VideoProcessor {
 
         let duration = end_time - start_time;
 
-        let output = Command::new("ffmpeg")
-            .args([
-                "-i",
-                video_path,
-                "-ss",
-                &start_time.to_string(),
-                "-t",
-                &duration.to_string(),
-                "-c",
-                "copy",
-                "-y",
-                output_path,
-            ])
-            .stderr(Stdio::piped())
-            .output()
-            .await
-            .context("Failed to run ffmpeg for clip extraction")?;
-
-        if !output.status.success() {
-            // Try re-encoding if copy fails
-            let output = Command::new("ffmpeg")
+        let output = output_with_timeout(
+            Command::new("ffmpeg")
                 .args([
                     "-i",
                     video_path,
@@ -194,16 +177,38 @@ impl VideoProcessor {
                     &start_time.to_string(),
                     "-t",
                     &duration.to_string(),
-                    "-c:v",
-                    "libx264",
-                    "-c:a",
-                    "aac",
+                    "-c",
+                    "copy",
                     "-y",
                     output_path,
                 ])
-                .stderr(Stdio::piped())
-                .output()
-                .await?;
+                .stderr(Stdio::piped()),
+            "ffmpeg for clip extraction",
+        )
+        .await?;
+
+        if !output.status.success() {
+            // Try re-encoding if copy fails
+            let output = output_with_timeout(
+                Command::new("ffmpeg")
+                    .args([
+                        "-i",
+                        video_path,
+                        "-ss",
+                        &start_time.to_string(),
+                        "-t",
+                        &duration.to_string(),
+                        "-c:v",
+                        "libx264",
+                        "-c:a",
+                        "aac",
+                        "-y",
+                        output_path,
+                    ])
+                    .stderr(Stdio::piped()),
+                "ffmpeg for clip re-encode",
+            )
+            .await?;
 
             if !output.status.success() {
                 anyhow::bail!(
@@ -301,7 +306,7 @@ impl VideoProcessor {
             &output_path,
         ]);
 
-        let output = cmd.stderr(Stdio::piped()).output().await?;
+        let output = output_with_timeout(cmd.stderr(Stdio::piped()), "ffmpeg render").await?;
 
         if !output.status.success() {
             anyhow::bail!(
@@ -333,20 +338,22 @@ impl VideoProcessor {
     ) -> Result<()> {
         info!("Adding subtitles to video");
 
-        let output = Command::new("ffmpeg")
-            .args([
-                "-i",
-                video_path,
-                "-vf",
-                &format!("subtitles={}", srt_path),
-                "-c:a",
-                "copy",
-                "-y",
-                output_path,
-            ])
-            .stderr(Stdio::piped())
-            .output()
-            .await?;
+        let output = output_with_timeout(
+            Command::new("ffmpeg")
+                .args([
+                    "-i",
+                    video_path,
+                    "-vf",
+                    &format!("subtitles={}", srt_path),
+                    "-c:a",
+                    "copy",
+                    "-y",
+                    output_path,
+                ])
+                .stderr(Stdio::piped()),
+            "ffmpeg for subtitles",
+        )
+        .await?;
 
         if !output.status.success() {
             anyhow::bail!(

--- a/tools/mcp/mcp_virtual_character/src/audio.rs
+++ b/tools/mcp/mcp_virtual_character/src/audio.rs
@@ -255,10 +255,7 @@ impl Default for AudioDownloader {
 impl AudioDownloader {
     /// Create a new audio downloader.
     pub fn new() -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .unwrap_or_default();
+        let client = mcp_core::http::build_client_or_default(Duration::from_secs(30));
         Self { client }
     }
 

--- a/tools/mcp/mcp_virtual_character/src/server.rs
+++ b/tools/mcp/mcp_virtual_character/src/server.rs
@@ -19,6 +19,16 @@ use crate::types::{
     SequenceEvent,
 };
 
+/// Seconds since the Unix epoch as `f64`. Returns `0.0` if the system clock is
+/// set before the epoch rather than panicking on the (practically impossible)
+/// error case.
+fn unix_secs_f64() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}
+
 /// Server state shared across all tools.
 #[derive(Clone)]
 pub struct ServerRefs {
@@ -41,13 +51,11 @@ impl ServerRefs {
     /// Check if backend is connected and return an error message if not.
     async fn check_connected(&self) -> Option<String> {
         let backend = self.backend.read().await;
-        if backend.is_none() {
-            return Some("No backend connected. Use set_backend first.".to_string());
+        match backend.as_ref() {
+            None => Some("No backend connected. Use set_backend first.".to_string()),
+            Some(b) if !b.is_connected() => Some("Backend is not connected.".to_string()),
+            Some(_) => None,
         }
-        if !backend.as_ref().unwrap().is_connected() {
-            return Some("Backend is not connected.".to_string());
-        }
-        None
     }
 }
 
@@ -290,10 +298,7 @@ impl Tool for SendAnimationTool {
             return Ok(ToolResult::error(e));
         }
 
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs_f64();
+        let timestamp = unix_secs_f64();
 
         let mut animation = CanonicalAnimationData::new(timestamp);
 
@@ -657,12 +662,7 @@ impl Tool for CreateSequenceTool {
                 .and_then(|v| v.as_str())
                 .map(String::from),
             loop_sequence: args.get("loop").and_then(|v| v.as_bool()).unwrap_or(false),
-            created_timestamp: Some(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs_f64(),
-            ),
+            created_timestamp: Some(unix_secs_f64()),
             ..Default::default()
         };
 
@@ -796,11 +796,11 @@ impl Tool for PlaySequenceTool {
         }
 
         let sequence_guard = self.server.current_sequence.read().await;
-        if sequence_guard.is_none() {
+        let Some(sequence) = sequence_guard.as_ref() else {
             return Ok(ToolResult::error("No sequence to play."));
-        }
+        };
 
-        let seq_name = sequence_guard.as_ref().unwrap().name.clone();
+        let seq_name = sequence.name.clone();
         *self.server.sequence_playing.write().await = true;
 
         // Note: Actual sequence execution would be implemented here
@@ -1041,10 +1041,7 @@ impl Tool for SendVRCEmoteTool {
             )));
         }
 
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs_f64();
+        let timestamp = unix_secs_f64();
 
         let mut params = HashMap::new();
         let mut avatar_params = serde_json::Map::new();

--- a/tools/rust/automation-cli/src/main.rs
+++ b/tools/rust/automation-cli/src/main.rs
@@ -1,3 +1,13 @@
+//! automation-cli: unified CLI for CI/CD orchestration and automation.
+//!
+//! Wraps the project's container-first CI/CD workflow (formatting, linting,
+//! testing, and building across the Python and Rust packages) behind a single
+//! Rust binary, and also launches local services. It is the preferred entry
+//! point over the legacy `automation/ci-cd/run-ci.sh` shell wrappers, which
+//! delegate to this binary when it is built.
+//!
+//! Run `automation-cli ci list` to see the available CI stages.
+
 use clap::{Parser, Subcommand};
 
 mod commands;

--- a/tools/rust/board-manager/README.md
+++ b/tools/rust/board-manager/README.md
@@ -64,6 +64,7 @@ Requires `.agents.yaml` in the repository root with:
 
 - `GITHUB_TOKEN` - GitHub API token with project access
 - `GITHUB_REPOSITORY` - Repository in `owner/repo` format
+- `BOARD_MANAGER_HTTP_TIMEOUT_SECS` - Total per-request timeout for GitHub API calls (default: 30)
 
 ## See Also
 

--- a/tools/rust/board-manager/src/client.rs
+++ b/tools/rust/board-manager/src/client.rs
@@ -25,6 +25,16 @@ const INITIAL_BACKOFF_SECS: u64 = 1;
 /// Maximum backoff duration.
 const MAX_BACKOFF_SECS: u64 = 60;
 
+/// Default total request timeout in seconds.
+const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 30;
+
+/// Connection-establishment timeout in seconds (fail fast on a dead host
+/// instead of waiting for the full request timeout).
+const CONNECT_TIMEOUT_SECS: u64 = 10;
+
+/// Env var overriding the total request timeout.
+const HTTP_TIMEOUT_ENV: &str = "BOARD_MANAGER_HTTP_TIMEOUT_SECS";
+
 /// GraphQL client for GitHub API.
 pub struct GraphQLClient {
     client: Client,
@@ -34,8 +44,15 @@ pub struct GraphQLClient {
 impl GraphQLClient {
     /// Create a new GraphQL client.
     pub fn new(token: String) -> Result<Self> {
+        let timeout_secs = std::env::var(HTTP_TIMEOUT_ENV)
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&s| s > 0)
+            .unwrap_or(DEFAULT_HTTP_TIMEOUT_SECS);
+
         let client = Client::builder()
-            .timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(timeout_secs))
+            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
             .build()
             .map_err(BoardError::Http)?;
 
@@ -142,6 +159,17 @@ impl GraphQLClient {
             return Err(BoardError::Auth(
                 "Forbidden - check permissions".to_string(),
             ));
+        }
+
+        // Surface other non-success statuses (e.g. 5xx) as a retryable error
+        // instead of attempting to parse the body as a GraphQL response, which
+        // would otherwise yield a silent empty result.
+        if !status.is_success() {
+            let error_body = response.text().await.unwrap_or_default();
+            return Err(BoardError::GraphQL(format!(
+                "GraphQL API HTTP error: {} - {}",
+                status, error_body
+            )));
         }
 
         let body: Value = response.json().await?;

--- a/tools/rust/gh-validator/src/main.rs
+++ b/tools/rust/gh-validator/src/main.rs
@@ -563,10 +563,18 @@ fn get_current_branch_pr(gh_path: &std::path::Path, repo: Option<&str>) -> Optio
     }
 
     let json_str = String::from_utf8(output.stdout).ok()?;
+    parse_pr_view_json(&json_str)
+}
 
-    // Parse JSON manually (avoid adding serde dependency)
-    // Format: {"number":123,"url":"https://..."} or {"number": 123, "url": "..."}
-    // Handle optional whitespace after colons
+/// Parse the JSON returned by `gh pr view --json number,url`.
+///
+/// Hand-rolled to avoid pulling a serde dependency in for this single,
+/// fixed-shape payload. Tolerates optional whitespace after colons and
+/// either field ordering. Returns `None` if either field is missing or
+/// malformed, e.g.:
+/// - `{"number":123,"url":"https://..."}`
+/// - `{"number": 123, "url": "https://..."}`
+fn parse_pr_view_json(json_str: &str) -> Option<(u32, String)> {
     let number = json_str.find("\"number\":").and_then(|i| {
         let start = i + 9;
         let rest = json_str[start..].trim_start();
@@ -764,5 +772,64 @@ mod tests {
             "--notes-file",
             "/tmp/notes.md"
         ])));
+    }
+
+    #[test]
+    fn test_parse_pr_view_json_compact() {
+        let json = r#"{"number":123,"url":"https://github.com/o/r/pull/123"}"#;
+        assert_eq!(
+            parse_pr_view_json(json),
+            Some((123, "https://github.com/o/r/pull/123".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_view_json_with_whitespace() {
+        let json = r#"{"number": 456, "url": "https://github.com/o/r/pull/456"}"#;
+        assert_eq!(
+            parse_pr_view_json(json),
+            Some((456, "https://github.com/o/r/pull/456".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_view_json_field_order_independent() {
+        let json = r#"{"url":"https://example.com/pull/7","number":7}"#;
+        assert_eq!(
+            parse_pr_view_json(json),
+            Some((7, "https://example.com/pull/7".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_view_json_missing_number() {
+        let json = r#"{"url":"https://github.com/o/r/pull/1"}"#;
+        assert_eq!(parse_pr_view_json(json), None);
+    }
+
+    #[test]
+    fn test_parse_pr_view_json_missing_url() {
+        let json = r#"{"number":99}"#;
+        assert_eq!(parse_pr_view_json(json), None);
+    }
+
+    #[test]
+    fn test_parse_pr_view_json_non_numeric_number() {
+        let json = r#"{"number":"abc","url":"https://x/pull/1"}"#;
+        assert_eq!(parse_pr_view_json(json), None);
+    }
+
+    #[test]
+    fn test_parse_pr_view_json_empty_and_garbage() {
+        assert_eq!(parse_pr_view_json(""), None);
+        assert_eq!(parse_pr_view_json("not json at all"), None);
+        assert_eq!(parse_pr_view_json("{}"), None);
+    }
+
+    #[test]
+    fn test_parse_pr_view_json_unterminated_url() {
+        // Opening quote present but no closing quote -> None, no panic.
+        let json = r#"{"number":5,"url":"https://github.com/o/r/pull/5"#;
+        assert_eq!(parse_pr_view_json(json), None);
     }
 }

--- a/tools/rust/github-agents-cli/src/review/agents/openrouter.rs
+++ b/tools/rust/github-agents-cli/src/review/agents/openrouter.rs
@@ -9,7 +9,7 @@ use super::ReviewAgent;
 use crate::error::{Error, Result};
 
 /// Default model for OpenRouter reviews
-const DEFAULT_MODEL: &str = "qwen/qwen3.6-plus";
+const DEFAULT_MODEL: &str = "qwen/qwen3.7-max";
 
 /// OpenRouter API endpoint
 const OPENROUTER_API_URL: &str = "https://openrouter.ai/api/v1/chat/completions";

--- a/tools/rust/github-agents-cli/src/security/manager.rs
+++ b/tools/rust/github-agents-cli/src/security/manager.rs
@@ -14,6 +14,14 @@ use tracing::{debug, info, warn};
 
 use crate::error::Error;
 
+/// Built-in fallback admin, used when neither a config file nor the
+/// `AI_AGENT_DEFAULT_ADMIN` environment variable supplies one.
+const BUILTIN_DEFAULT_ADMIN: &str = "AndrewAltimit";
+
+/// Environment variable overriding the built-in default admin(s).
+/// Accepts a comma-separated list of usernames.
+const DEFAULT_ADMIN_ENV: &str = "AI_AGENT_DEFAULT_ADMIN";
+
 lazy_static! {
     /// Pattern for trigger comments: [Action] with optional [Agent]
     static ref TRIGGER_PATTERN: Regex =
@@ -56,8 +64,23 @@ fn default_enabled() -> bool {
     true
 }
 
+/// Resolve the default admin list from an optional env value.
+///
+/// Split out as a pure function so it can be tested without mutating global
+/// process environment (which would race with parallel tests).
+fn parse_default_admins(env_value: Option<&str>) -> Vec<String> {
+    match env_value {
+        Some(val) if !val.trim().is_empty() => val
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => vec![BUILTIN_DEFAULT_ADMIN.to_string()],
+    }
+}
+
 fn default_agent_admins() -> Vec<String> {
-    vec!["AndrewAltimit".to_string()]
+    parse_default_admins(env::var(DEFAULT_ADMIN_ENV).ok().as_deref())
 }
 
 fn default_rate_limit_window() -> u64 {
@@ -473,6 +496,26 @@ mod tests {
         );
         assert!(allowed);
         assert!(reason.is_empty());
+    }
+
+    #[test]
+    fn test_parse_default_admins() {
+        // Unset / empty -> built-in fallback
+        assert_eq!(parse_default_admins(None), vec![BUILTIN_DEFAULT_ADMIN]);
+        assert_eq!(parse_default_admins(Some("")), vec![BUILTIN_DEFAULT_ADMIN]);
+        assert_eq!(
+            parse_default_admins(Some("   ")),
+            vec![BUILTIN_DEFAULT_ADMIN]
+        );
+
+        // Single override
+        assert_eq!(parse_default_admins(Some("Alice")), vec!["Alice"]);
+
+        // Comma-separated list with surrounding whitespace and empties
+        assert_eq!(
+            parse_default_admins(Some(" Alice , Bob ,, ")),
+            vec!["Alice", "Bob"]
+        );
     }
 
     #[test]

--- a/tools/rust/github-agents-cli/src/security/manager.rs
+++ b/tools/rust/github-agents-cli/src/security/manager.rs
@@ -69,13 +69,23 @@ fn default_enabled() -> bool {
 /// Split out as a pure function so it can be tested without mutating global
 /// process environment (which would race with parallel tests).
 fn parse_default_admins(env_value: Option<&str>) -> Vec<String> {
-    match env_value {
-        Some(val) if !val.trim().is_empty() => val
+    let admins: Vec<String> = match env_value {
+        Some(val) => val
             .split(',')
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .collect(),
-        _ => vec![BUILTIN_DEFAULT_ADMIN.to_string()],
+        None => Vec::new(),
+    };
+
+    // Fall back to the built-in admin if the env var is unset, empty, or
+    // contains only separators/whitespace (e.g. ",,," or "   "). An empty
+    // admin list must never be returned: depending on downstream allow-list
+    // checks it could lock out every user or allow everyone.
+    if admins.is_empty() {
+        vec![BUILTIN_DEFAULT_ADMIN.to_string()]
+    } else {
+        admins
     }
 }
 
@@ -505,6 +515,17 @@ mod tests {
         assert_eq!(parse_default_admins(Some("")), vec![BUILTIN_DEFAULT_ADMIN]);
         assert_eq!(
             parse_default_admins(Some("   ")),
+            vec![BUILTIN_DEFAULT_ADMIN]
+        );
+
+        // Only separators / whitespace -> built-in fallback (never an empty list)
+        assert_eq!(parse_default_admins(Some(",")), vec![BUILTIN_DEFAULT_ADMIN]);
+        assert_eq!(
+            parse_default_admins(Some(",,,")),
+            vec![BUILTIN_DEFAULT_ADMIN]
+        );
+        assert_eq!(
+            parse_default_admins(Some(" , , ")),
             vec![BUILTIN_DEFAULT_ADMIN]
         );
 

--- a/tools/rust/wrapper-common/src/binary_finder.rs
+++ b/tools/rust/wrapper-common/src/binary_finder.rs
@@ -118,14 +118,30 @@ pub fn find_real_binary(binary_name: &str) -> Result<PathBuf> {
 /// The variable is binary-specific (e.g., `__WRAPPER_GUARD_RECURSION_GIT`)
 /// so that gh-validator setting its guard doesn't prevent git-guard from
 /// running when the real `gh` binary internally calls `git`.
+///
+/// # Threading contract
+///
+/// In edition 2024 `std::env::set_var` is `unsafe` because the process
+/// environment is global mutable state shared with the C runtime: a
+/// concurrent `getenv`/`setenv` from any other thread (including ones spawned
+/// by linked C libraries) is a data race with undefined behavior.
+///
+/// Callers **must** only invoke this from the main thread, while no other
+/// thread can read or write the environment, and immediately before the
+/// `exec_binary()` call that replaces the process image. The wrapper binaries
+/// (git-guard, gh-validator) uphold this: they are single-threaded up to this
+/// point and call `set_recursion_guard()` as the last step before `exec()`.
+/// Do not call this once a multi-threaded runtime (e.g. a tokio worker pool)
+/// has been started.
 pub fn set_recursion_guard(binary_name: &str) {
     let var = format!(
         "{}{}",
         RECURSION_GUARD_PREFIX,
         binary_name.to_ascii_uppercase()
     );
-    // SAFETY: this is called single-threaded just before exec() replaces
-    // the process image, so no other threads are affected.
+    // SAFETY: per the documented threading contract above, this runs on the
+    // sole (main) thread immediately before exec() replaces the process image,
+    // so there is no concurrent reader/writer of the environment to race with.
     unsafe {
         std::env::set_var(var, "1");
     }

--- a/tools/rust/wrapper-common/src/integrity.rs
+++ b/tools/rust/wrapper-common/src/integrity.rs
@@ -11,7 +11,7 @@
 /// Otherwise return `false` (normal execution continues).
 ///
 /// # Arguments
-/// * `args` - Command-line arguments (after skipping argv[0])
+/// * `args` - Command-line arguments (after skipping `argv[0]`)
 /// * `wrapper_name` - Name of the wrapper (e.g., "git-guard")
 /// * `source_hash` - The compile-time embedded source hash
 pub fn check_integrity_flag(args: &[String], wrapper_name: &str, source_hash: &str) -> bool {


### PR DESCRIPTION
## Summary

A robustness, correctness, and testability pass over the Rust tooling in `tools/mcp/` (MCP servers + `mcp-core`) and `tools/rust/` (CLIs). The throughline: a malformed LLM argument or a slow upstream should never crash a server or hang it indefinitely, and the shared library should make the safe path the easy path.

## Robustness

- **Tool-execution panic boundary** (`mcp-core`): `tools/call` now runs each tool inside a `catch_unwind` boundary. A panic (e.g. a stray `.unwrap()` on malformed input) is caught and returned to the client as an MCP tool error (`isError: true`) instead of unwinding the connection task or crashing the server.
- **Subprocess timeouts**: `blender` and `video-editor` previously spawned `ffmpeg`/`ffprobe`/`whisper`/Blender with no bound. They now run under a configurable `tokio::time::timeout` with `kill_on_drop`, so a wedged subprocess can no longer hang the server (`BLENDER_JOB_TIMEOUT_SECS`, `VIDEO_EDITOR_SUBPROCESS_TIMEOUT_SECS`).
- **Removed panic-prone unwraps** in `virtual-character` (clock/Option-after-check), `gaea2` connection normalization, and `meme-generator` multipart construction — converted to typed errors or graceful fallbacks.
- **No more startup-panicking HTTP clients**: the four `new() -> Self` constructors that did `.build().expect(...)` now fall back to a default client instead of aborting the server.

## Correctness

- **board-manager GraphQL bug**: the GraphQL path did not check HTTP status, so a 5xx fell through to JSON parsing and produced a silent empty response that the retry loop treated as success. It now surfaces non-success statuses as retryable errors (mirroring the REST path), and gains a `connect_timeout` plus a configurable total timeout (`BOARD_MANAGER_HTTP_TIMEOUT_SECS`).

## Features / library improvements

- **`#[mcp_tool]` macro fixed and extended**: the macro previously emitted illegal placeholder parameter types and did not compile — it now generates a typed `execute_impl` that deserializes arguments into their declared types and returns `InvalidParameters` on bad input. Added `#[mcp(state)]` to inject shared state (store/client/registry) into the generated tool via a `new(...)` constructor, so real stateful tools can use it.
- **Shared HTTP client helper** (`mcp_core::http`): `build_client()` / `build_client_or_default()` apply a consistent connect timeout on top of the caller's request timeout. Migrated six servers off the duplicated `Client::builder()...expect()` blocks.
- **Extracted the hardcoded default admin** in `github-agents-cli` to a named constant with an `AI_AGENT_DEFAULT_ADMIN` env override (comma-separated), so the template is not tied to a single username. Behavior is unchanged when unset.

## Tests

- Adopted the shared `mcp-testing` harness in `sprite-sheet` with execute-path tests that drive a multi-tool workflow (create -> add layer -> set pixels -> status) over the real `Tool::execute` JSON boundary, plus error paths (missing arg, unknown project, unknown tool). None of the standalone servers depended on the harness before; this establishes the reusable pattern.
- `gh-validator`: extracted the hand-rolled `gh pr view --json` parser into a pure function and covered it with 8 unit tests (whitespace/ordering tolerance, missing/non-numeric/unterminated, empty + garbage input).
- New regression test for the panic boundary; canonical macro test for `#[mcp_tool]` including the stateful form.

## Documentation

- Documented the new environment variables in the relevant server/CLI READMEs and `agents/security.md`.
- Added a "Shared HTTP client" section and a `TestServer` usage example to `mcp_core_rust/README.md`, and documented the panic boundary.
- Expanded the `wrapper-common` `set_recursion_guard()` docs with an explicit threading contract explaining why `std::env::set_var` is `unsafe` in edition 2024.

## Verification

Each touched crate verified with `cargo clippy --all-targets`, `cargo test`, and `cargo fmt --check`. Pre-existing clippy style warnings unrelated to these changes were left untouched.

> Note: this branch also carries one small config commit bumping the PR-review model to `qwen/qwen3.7-max` (`.agents.yaml`), made directly on the branch.

Generated with [Claude Code](https://claude.com/claude-code)
