### PR TITLE
docs(projections): revise WMD proliferation report to v2.1 (mid-2026 refresh)

### DIFF
--- a/docs/projections/ai-agents-wmd-proliferation.md
+++ b/docs/projections/ai-agents-wmd-proliferation.md
@@ -4,17 +4,23 @@
 
 **Type**: Policy Research - Defensive Analysis
 
+**Document ID**: ETRA-2026-WMD-001
+
 **License**: MIT / Unlicense (Public Domain)
 
-**Version**: 2.0
+**Version**: 2.1
 
-**Date**: February 2026
+**Date**: July 2026
+
+**Related Documents**: ETRA-2026-ESP-001 (Espionage Operations), ETRA-2025-AEA-001 (Economic Actors), ETRA-2025-FIN-001 (Financial Integrity), ETRA-2026-IC-001 (Institutional Erosion), ETRA-2026-PTR-001 (Political Targeting)
 
 ---
 
 ## About This Document
 
 This is a **public policy research document** analyzing how AI capabilities may affect WMD proliferation risks. It is released under permissive open-source licenses to support broad discussion of these issues.
+
+> **Capability snapshot date**: Model capabilities and policy developments described in this document reflect publicly available systems and published assessments as of **early July 2026**. AI capability is a moving target; the projection's conclusions are intended to be robust to specific model iterations rather than pinned to any single release. Where a named model or evaluation is cited, treat it as an illustrative data point on a trend, not a fixed endpoint.
 
 **Intended audiences**:
 - Policy researchers and analysts
@@ -47,7 +53,7 @@ Throughout this document, key claims are tagged with epistemic status:
 
 ## Executive Summary
 
-This projection examines how autonomous AI agents may alter the proliferation landscape for weapons of mass destruction (WMD), including biological, chemical, and nuclear weapons. We analyze current technological capabilities as of early 2026, project likely scenarios through 2030, and examine the complex interplay between AI capabilities, existing physical barriers, and potential defensive adaptations.
+This projection examines how autonomous AI agents may alter the proliferation landscape for weapons of mass destruction (WMD), including biological, chemical, and nuclear weapons. We analyze current technological capabilities as of mid-2026, project likely scenarios through 2030, and examine the complex interplay between AI capabilities, existing physical barriers, and potential defensive adaptations.
 
 **Key Findings:**
 
@@ -64,14 +70,15 @@ This projection examines how autonomous AI agents may alter the proliferation la
 
 **Why Now? What Changed 2023→2026:**
 
-| Capability Shift | 2023 State | 2025-2026 State | Impact |
+| Capability Shift | 2023 State | Mid-2026 State | Impact |
 |-----------------|------------|-----------------|--------|
 | **Agentic autonomy** | Chatbots provided information | Agents execute multi-step tasks with tool use, self-correction, persistence, and delegation to sub-agents **[O]** | Shifts from "knowledge" to "autonomous execution"; multi-agent orchestration compounds capability |
-| **Reasoning models** | No explicit chain-of-thought optimization | Dedicated reasoning models (o3/o4-mini, Claude extended thinking, DeepSeek R1) with multi-step planning **[O]** | Enables complex synthesis planning and optimization previously requiring expert-level reasoning |
+| **Reasoning models** | No explicit chain-of-thought optimization | Dedicated reasoning models are now standard, closed and open-weight alike (Claude, o-series, DeepSeek V4 with tiered "think" modes), with multi-step planning **[O]** | Enables complex synthesis planning and optimization previously requiring expert-level reasoning |
 | **Vision-language models** | Text-only instruction | Real-time visual interpretation of lab procedures; wearable integration **[O]** | Bridges tacit knowledge gap; smart glasses enable hands-free guidance |
 | **Computer Use / Tool Use** | Manual web interaction | Agents can browse, fill forms, manage procurement; MCP enables direct hardware control **[O]** | Enables procurement obfuscation at scale; direct laboratory equipment integration |
-| **Biological design tools** | AlphaFold 2 (structure prediction) | AlphaFold 3, ESM3, Evo (evolutionary-scale genomics), RFdiffusion (de novo protein design) **[O]** | Optimization beyond information retrieval; generative biological design |
-| **Open-weight proliferation** | Limited high-capability open models | DeepSeek R1/V3, Llama 3.3, Qwen 2.5, Mistral Large with mature fine-tuning ecosystems **[O]** | Guardrail bypass via local deployment; open reasoning models raise capability floor substantially |
+| **Biological design tools** | AlphaFold 2 (structure prediction) | AlphaFold 3, ESM3, Evo (evolutionary-scale genomics), RFdiffusion (de novo protein design), and sequence-to-function models benchmarked against expert humans **[O]** | Optimization beyond information retrieval; generative biological design |
+| **Open-weight proliferation** | Limited high-capability open models | Frontier-grade open-weight reasoning models are freely downloadable (DeepSeek V4, Qwen 3.5, Llama 4, Kimi K2.6), many MIT-licensed, with mature fine-tuning ecosystems **[O]** | Guardrail bypass via local deployment; open reasoning models raise the capability floor substantially |
+| **Threshold crossing** | Below any weapons-uplift threshold | A frontier developer judged its most capable mid-2026 model to have crossed the "non-novel CB weapons uplift" (CB-1) threshold, though not the "novel weapon" (CB-2) threshold **[O]** | The first public developer acknowledgement that a deployed model materially uplifts chemical/biological weapons work for actors with basic technical backgrounds |
 
 **Scope Limitations**: This document analyzes capabilities and trends for defensive policy purposes. It does not provide operational guidance and explicitly omits technical implementation details that could enable harm. All information draws on publicly available academic literature and policy discussions.
 
@@ -146,29 +153,30 @@ To prevent misreading, we explicitly clarify:
 8. [Gene Drives: Long-Horizon Governance Gap](#8-gene-drives-long-horizon-governance-gap)
 9. [Deployment Vectors: Aerosol Systems and Autonomous Delivery](#9-deployment-vectors-aerosol-systems-and-autonomous-delivery)
 10. [The Cyber-Physical Convergence](#10-the-cyber-physical-convergence)
-11. [Counterarguments and Structural Barriers](#11-counterarguments-and-structural-barriers)
-12. [The Attribution Problem](#12-the-attribution-problem)
-13. [International Variance](#13-international-variance)
-14. [Second-Order Effects](#14-second-order-effects)
-15. [Policy Recommendations by Stakeholder Type](#15-policy-recommendations-by-stakeholder-type)
-16. [Uncertainties and Alternative Scenarios](#16-uncertainties-and-alternative-scenarios)
-17. [Signals and Early Indicators](#17-signals-and-early-indicators)
-18. [Civil Liberties and Research Freedom Considerations](#18-civil-liberties-and-research-freedom-considerations)
-19. [Conclusion](#19-conclusion)
+11. [Proliferation Financing and Procurement Obfuscation](#11-proliferation-financing-and-procurement-obfuscation)
+12. [Counterarguments and Structural Barriers](#12-counterarguments-and-structural-barriers)
+13. [The Attribution Problem](#13-the-attribution-problem)
+14. [International Variance](#14-international-variance)
+15. [Second-Order Effects](#15-second-order-effects)
+16. [Policy Recommendations by Stakeholder Type](#16-policy-recommendations-by-stakeholder-type)
+17. [Uncertainties and Alternative Scenarios](#17-uncertainties-and-alternative-scenarios)
+18. [Signals and Early Indicators](#18-signals-and-early-indicators)
+19. [Civil Liberties and Research Freedom Considerations](#19-civil-liberties-and-research-freedom-considerations)
+20. [Conclusion](#20-conclusion)
 
 ---
 
 ## Reading Guide
 
-This document is comprehensive (~2400 lines). For targeted reading based on your role:
+This document is comprehensive. For targeted reading based on your role:
 
 | Reader Profile | Recommended Sections | Time |
 |---------------|---------------------|------|
-| **Policymaker / Executive** | Executive Summary (both versions) + Section 15 (Policy Recommendations) + Section 16 (Scenarios) | ~20 min |
-| **Security Practitioner** | Sections 9-12 (Deployment, Cyber-Physical, Counterarguments, Attribution) + Section 17 (Signals/Indicators) | ~25 min |
-| **AI Safety Researcher** | Sections 1-3 (Methodology, Frameworks, Technology) + Section 11 (Counterarguments) + Appendix E-F (Confidence/Measurement) | ~30 min |
-| **Biosecurity Specialist** | Sections 5, 8 (Biological, Gene Drives) + Companion Research box + Section 15 (Policy) | ~20 min |
-| **General Reader** | Executive Summary (One-Page) + Section 11 (Counterarguments) + Section 18 (Civil Liberties) + Conclusion | ~15 min |
+| **Policymaker / Executive** | Executive Summary (both versions) + Section 16 (Policy Recommendations) + Section 17 (Scenarios) | ~20 min |
+| **Security Practitioner** | Sections 9-13 (Deployment, Cyber-Physical, Proliferation Financing, Counterarguments, Attribution) + Section 18 (Signals/Indicators) | ~25 min |
+| **AI Safety Researcher** | Sections 1-3 (Methodology, Frameworks, Technology) + Section 12 (Counterarguments) + Appendix E-F (Confidence/Measurement) | ~30 min |
+| **Biosecurity Specialist** | Sections 5, 8 (Biological, Gene Drives) + Companion Research box + Section 16 (Policy) | ~20 min |
+| **General Reader** | Executive Summary (One-Page) + Section 12 (Counterarguments) + Section 19 (Civil Liberties) + Conclusion | ~15 min |
 
 ---
 
@@ -190,7 +198,7 @@ Cross-references to these reports appear throughout this document where their an
 ## 1. Introduction and Methodology
 ### Purpose
 
-The development of weapons of mass destruction has historically required either state-level resources or exceptional individual expertise combined with significant infrastructure. The Manhattan Project employed over 125,000 people. Aum Shinrikyo, despite millions of dollars and multiple PhD scientists, failed to effectively weaponize biological agents. These historical constraints have provided a de facto barrier to WMD proliferation.
+The development of weapons of mass destruction has historically required either state-level resources or exceptional individual expertise combined with significant infrastructure. The Manhattan Project employed over 125,000 people.[^manhattan] Aum Shinrikyo, despite millions of dollars and multiple PhD scientists, failed to effectively weaponize biological agents. These historical constraints have provided a de facto barrier to WMD proliferation.
 
 We are now entering an era where autonomous AI agents capable of complex multi-step planning, information synthesis, and real-time adaptation become widely accessible. This projection examines whether and how AI agents might erode these historical barriers.
 
@@ -212,18 +220,29 @@ Readers should interpret this analysis through that lens: the primary concern is
 
 ### Methodology
 
-This analysis draws on:
+This is a synthesis of publicly available material. It does not report any first-party study. Specifically, it draws on:
 
-- **Current capability assessment** of AI agent systems and synthetic biology tools as deployed through early 2026
-- **Historical case analysis** of WMD development programs (state and non-state)
+- **Published capability assessments** of AI agent systems and synthetic biology tools deployed through mid-2026, including frontier-model system cards and their published red-team and uplift-trial results
+- **Historical case analysis** of WMD development programs (state and non-state) from the public record
 - **Dual-Use Research of Concern (DURC)** literature and policy debates
-- **Expert consultation** across biosecurity, nuclear security, and AI safety domains
-- **Red team exercises** examining potential adversarial applications (conducted under controlled conditions)
+- **Published expert assessments** across biosecurity, nuclear security, and AI safety, including the RAND biological-attack red-team studies and government risk reports cited throughout
+- **Published red-team and uplift-trial findings** from frontier AI developers and independent evaluators (for example the chemical and biological uplift trials reported in AI system cards)
+
+To be explicit about provenance: the author conducted no original expert consultation, no interviews, and no red-team or uplift exercises for this document. Every empirical claim traces to a cited public source. Where this document uses the phrase "our assessment," it means the author's synthesis of that public evidence, offered as decision support, not as an authoritative or classified judgment.
 
 We deliberately avoid:
 - Specific technical implementation details for weapon synthesis
 - Named pathogen sequences or synthesis routes
 - Information not already publicly available in academic literature
+
+### Limitations and Positionality
+
+Readers should weigh this analysis accordingly:
+
+- **Independent single-author synthesis.** This is not an institutional or peer-reviewed assessment. It aggregates and interprets public sources; it does not have access to classified intelligence, proprietary evaluation data, or non-public incident reporting.
+- **Open-source ceiling.** Absence of public evidence is not evidence of absence (see "What We've Observed," Section 3). The most decision-relevant information about actual threat activity is likely non-public.
+- **Subjective probabilities.** All scenario probabilities are subjective priors for decision support, not empirical estimates (see the Probability Calibration Note in Section 17).
+- **Author standpoint.** The author's prior is that barrier reduction is real but that physical and operational barriers remain substantial. Readers who hold different priors on how fast tacit-knowledge and execution barriers are eroding should adjust the conclusions accordingly; the sensitivity analysis in Section 17 is provided partly to support that.
 
 ### Definitions
 
@@ -270,44 +289,35 @@ This analysis draws on several established theoretical frameworks from security 
 
 ### Unified Risk Model
 
-The following model underpins the analysis throughout this document:
+The following model underpins the analysis throughout this document. This is the single canonical risk equation used everywhere in the report, including the quantitative decomposition in Section 17:
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                           RISK MODEL                                     │
-│                                                                          │
-│   Risk = Capability × Access × Intent × Execution × (1-Interdiction)   │
-│                              ×                                           │
-│                         Impact Scale                                     │
-└─────────────────────────────────────────────────────────────────────────┘
+> **Risk = Capability-Access × Intent Prevalence × Operational Execution × (1 − Interdiction) × Impact Scale**
 
-┌──────────────────┬────────────────────┬──────────────────┬──────────────┐
-│     Factor       │   AI Contribution  │   Bio (2025→30)  │  Nuke (→30)  │
-├──────────────────┼────────────────────┼──────────────────┼──────────────┤
-│ Capability       │ HIGH (knowledge    │   ↑↑ Rising      │   → Stable   │
-│ (can attempt)    │ synthesis)         │                  │              │
-├──────────────────┼────────────────────┼──────────────────┼──────────────┤
-│ Access           │ MEDIUM (cloud labs,│   ↑ Rising       │   → Stable   │
-│ (materials/tools)│ synthesis services)│                  │   (fissile)  │
-├──────────────────┼────────────────────┼──────────────────┼──────────────┤
-│ Intent           │ NONE (AI doesn't   │   → Stable       │   → Stable   │
-│ (motivation)     │ create motivation) │                  │              │
-├──────────────────┼────────────────────┼──────────────────┼──────────────┤
-│ Execution        │ MEDIUM (guidance,  │   ↑ Rising       │   → Stable   │
-│ (attempt→success)│ troubleshooting)   │   (slow)         │              │
-├──────────────────┼────────────────────┼──────────────────┼──────────────┤
-│ Interdiction     │ MIXED (AI helps    │   ↓ Declining    │   → Stable   │
-│ (detection rate) │ both sides)        │   (pressure)     │   (strong)   │
-├──────────────────┼────────────────────┼──────────────────┼──────────────┤
-│ Impact Scale     │ LOW (physics/bio   │   Wide range     │ Catastrophic │
-│ (harm if success)│ constrain)         │                  │              │
-└──────────────────┴────────────────────┴──────────────────┴──────────────┘
+Where **Capability-Access** combines two sub-components the report tracks separately: the *cognitive* barrier (knowing what to do, where AI contributes most) and the *materials/tools* barrier (physical access, which AI largely cannot address). The table below shows how AI affects each factor and how the factor is trending for the highest-risk and lowest-risk weapon categories.
 
-Key insight: AI primarily affects Capability and Access (cognitive barriers).
-Physical barriers, Intent, and Impact Scale are largely AI-independent.
-```
+| Factor | AI Contribution | Bio (2025 to 2030) | Nuclear (to 2030) |
+|--------|-----------------|--------------------|-------------------|
+| **Capability** (cognitive: can attempt) | High: knowledge synthesis | Rising fast | Stable |
+| **Access** (materials/tools) | Medium: cloud labs, synthesis services | Rising | Stable (fissile barrier) |
+| **Intent Prevalence** (motivation) | None: AI does not create motivation | Stable | Stable |
+| **Operational Execution** (attempt to success) | Medium: guidance, troubleshooting | Rising (slowly) | Stable |
+| **Interdiction** (detection rate) | Mixed: AI helps both attackers and defenders | Declining (under pressure) | Stable (strong) |
+| **Impact Scale** (harm if success) | Low: physics and biology constrain | Wide range | Catastrophic |
 
-**How to read this model**: Each section of this report examines how AI affects specific multipliers in this equation. The probability decomposition in Section 16 applies this model quantitatively.
+**Key insight**: AI primarily affects Capability and Access, the cognitive barriers. Physical barriers, Intent Prevalence, and Impact Scale are largely AI-independent.
+
+**How to read this model**: Each section of this report examines how AI affects specific multipliers in this equation. The probability decomposition in Section 17 applies the same equation quantitatively, with Capability and Access combined into a single "Capability Access" term.
+
+### Capability Thresholds: The CB-1 / CB-2 Framework
+
+By mid-2026, frontier AI developers had converged on explicit capability thresholds for chemical and biological weapons, most visibly in one developer's Responsible Scaling Policy and Frontier Compliance Framework.[^fable5card] These thresholds are a useful shared vocabulary for defenders because they separate two very different risks that the "AI and bioweapons" discourse often blurs together:
+
+| Threshold | Definition | What it maps to in this report |
+|-----------|------------|--------------------------------|
+| **CB-1: non-novel weapons uplift** | The model can significantly help individuals or groups with *basic technical backgrounds* (for example undergraduate STEM) create, obtain, or deploy *known* chemical or biological weapons with catastrophic potential | Barrier reduction for T1-T3 actors on *existing* agents; the central near-term concern of this report |
+| **CB-2: novel weapons uplift** | The model can *functionally substitute* for the scarce world-leading expertise that is currently the primary barrier to *novel* chemical/biological weapons (end-to-end design, validation, formulation, and dissemination) | The tacit-knowledge / expertise-bottleneck barrier (Section 2, Section 12); a higher and less-certain bar |
+
+**Why this matters for the report's thesis**: As of mid-2026, the first public developer determination placed its most capable model *across CB-1 but not clearly across CB-2*, and explicitly warned that world-class expert substitution "may now be possible in a few areas."[^fable5card] This is consistent with this report's core finding: AI meaningfully uplifts T1-T3 actors working with known agents (CB-1), while the harder novel-weapon barrier (CB-2) is eroding but not yet clearly breached. The distinction also shapes defensive priorities: CB-1 risk is best addressed by chokepoint controls on materials and synthesis (which do not depend on how capable the model is), whereas CB-2 risk is where model-level access controls and capability evaluations matter most.
 
 ### The Democratization of Lethality
 
@@ -318,7 +328,7 @@ For WMD, this means:
 - The barrier was also cognitive (knowing what to do with materials)
 - AI specifically attacks the cognitive barrier while physical barriers remain
 
-> **Cross-reference**: The [Espionage Operations report](ai-agents-espionage-operations.md) frames the same dynamic as AI bypassing the "Handler Bottleneck" -- the cognitive/emotional bandwidth limitation that previously constrained intelligence operations to state-level actors. For WMD, the analogous concept is an "expertise bottleneck" that AI is beginning to erode for T1-T3 actors. The [Political Targeting report](ai-agents-political-targeting.md) extends Cronin's framework to show how AI reduces the "conspiracy footprint" required for planning complex operations -- directly relevant to WMD acquisition coordination.
+> **Cross-reference**: The [Espionage Operations report](ai-agents-espionage-operations.md) frames the same dynamic as AI bypassing the "Handler Bottleneck", the cognitive/emotional bandwidth limitation that previously constrained intelligence operations to state-level actors. For WMD, the analogous concept is an "expertise bottleneck" that AI is beginning to erode for T1-T3 actors. The [Political Targeting report](ai-agents-political-targeting.md) extends Cronin's framework to show how AI reduces the "conspiracy footprint" required for planning complex operations, directly relevant to WMD acquisition coordination.
 
 ### Dual-Use Research of Concern (DURC)
 
@@ -398,30 +408,34 @@ The balance varies significantly across WMD categories, which is why biological,
 | *NIST AI RMF* | NIST (2023) | AI risk management framework |
 | *Information Hazards* | Nick Bostrom (2011) | Framework for dangerous knowledge |
 | *The Unilateralist's Curse* | Bostrom & Ord (2015) | Why misuse becomes inevitable with proliferation |
-| *Operational Risks of AI in Biological Attacks* | RAND Corporation (2024) | Grounded assessment of current risk levels **[O]** |
+| *The Operational Risks of AI in Large-Scale Biological Attacks: Results of a Red-Team Study* | Mouton, Lucas, and Guest, RAND Corporation (2024) | Red-team study finding no measurable uplift from the then-current model generation **[O]**[^rand2024] |
 | *Countdown to Zero Day* | Kim Zetter (2014) | Stuxnet and cyber-physical attacks |
 
-### 2024-2026 Policy Developments
+### 2023-2026 Policy Developments
 
 | Reference | Date | Relevance |
 |-----------|------|-----------|
 | **Bletchley Declaration** | November 2023 | First international consensus on frontier AI risks including CBRN **[O]** |
 | **US Executive Order 14110** (Section 4.4) | October 2023 | Mandated DOE/DHS evaluation of AI role in CBRN threats; subsequently revoked January 2025 **[O]** |
 | **Seoul AI Safety Summit Commitments** | May 2024 | Extended Bletchley with specific bio-risk language **[O]** |
-| **OpenAI o1 Biological Uplift Evaluations** | 2024 | Human-in-the-loop tests of whether reasoning models help PhD-level biologists plan faster; found modest but measurable uplift **[O]** |
-| **RAND "Operational Risks" Report** | 2024 | Definitive "uplift" study finding limited current risk but monitoring needed **[O]** |
-| **Anthropic RSP Framework** | 2023-2024 | Responsible Scaling Policy with CBRN capability thresholds **[O]** |
-| **EU AI Act Implementation** | August 2025 | First comprehensive AI regulation; includes high-risk system requirements applicable to CBRN-adjacent uses **[O]** |
-| **EO 14110 Revocation** | January 2025 | US rescinded prior AI safety executive order; shifts regulatory landscape toward industry self-governance **[O]** |
-| **DeepSeek R1 Open Release** | January 2025 | Open-weight reasoning model matching frontier performance; demonstrated that reasoning capabilities can proliferate rapidly **[O]** |
-| **AI Seoul Summit Follow-up** | 2025 | Continued international coordination on frontier AI safety commitments **[O]** |
+| **DHS CWMD report on AI and CBRN** | April 2024 | US Department of Homeland Security assessment of AI-CBRN risk intersection, mandated by EO 14110 **[O]**[^dhscbrn] |
+| **RAND red-team biological-attack study** | 2024 | Red-team study finding no statistically significant uplift from the then-current LLM generation; recommended continued monitoring **[O]**[^rand2024] |
+| **OSTP Framework for Nucleic Acid Synthesis Screening** | April 2024 | US framework encouraging synthesis providers to screen orders and verify customers **[O]**[^naframework] |
+| **Anthropic Responsible Scaling Policy / Frontier Compliance Framework** | 2023-2026 | Capability thresholds for autonomy and for chemical/biological weapons (CB-1 non-novel, CB-2 novel) **[O]**[^fable5card] |
+| **EO 14110 revocation; EO 14179** | January 2025 | US rescinded the prior AI safety executive order (Jan 20) and issued "Removing Barriers to American Leadership in AI" (Jan 23), shifting toward lighter-touch governance and an AI Action Plan **[O]**[^eo14179] |
+| **UK AI Safety Institute becomes AI Security Institute** | February 2025 | Rebrand signaling a focus on security-relevant AI risks, explicitly including chemical and biological weapons and cyber-attacks **[O]**[^ukaisi] |
+| **EO "Improving the Safety and Security of Biological Research"** | May 2025 | Directs OSTP to revise or replace the 2024 synthesis-screening framework; makes framework adherence a condition of federal life-sciences funding for purchases on or after April 26, 2025 **[O]**[^bioeo2025] |
+| **America's AI Action Plan** | July 2025 | Successor US federal strategy emphasizing AI leadership, with national-security and biosecurity workstreams **[O]**[^eo14179] |
+| **EU AI Act GPAI obligations in force** | August 2025 | Obligations for general-purpose AI models apply; systemic-risk tier (models trained above 10^25 FLOP) carries safety-and-security duties under the GPAI Code of Practice; Commission enforcement from August 2026 **[O]**[^euaiact] |
+| **Open-weight frontier reasoning models proliferate** | 2025-2026 | DeepSeek V4, Qwen 3.5, Llama 4, and others ship frontier-grade reasoning weights, many MIT-licensed, largely without enforceable guardrails **[O]**[^openweight] |
+| **First public developer CB-1 threshold determination** | June 2026 | A frontier developer's system card judged its most capable model to have crossed the non-novel CB weapons uplift threshold (CB-1), while stopping short of the novel-weapon threshold (CB-2) with "significant uncertainty" **[O]**[^fable5card] |
 
 ---
 
 ## 3. The Current Technological Landscape (2025)
 ### AI Agent Capabilities
 
-AI agents in early 2026 can:
+AI agents in mid-2026 can:
 
 - Synthesize information from thousands of scientific papers in seconds
 - Conduct extended multi-step research tasks with minimal supervision
@@ -459,7 +473,7 @@ For biosecurity-relevant capabilities specifically:
 - Availability of VLM fine-tuning for scientific domains
 - Educational applications that may have dual-use potential
 
-**Current state assessment**: As of early 2026, VLMs can interpret laboratory images and provide general guidance, but reliable real-time procedure coaching remains limited. The gap between "understanding what's happening" and "reliably guiding a novice to success" remains significant but is narrowing.
+**Current state assessment**: As of mid-2026, VLMs can interpret laboratory images and provide general guidance, but reliable real-time procedure coaching remains limited. The gap between "understanding what's happening" and "reliably guiding a novice to success" remains significant but is narrowing.
 
 **Visual Troubleshooting Scenario** (for defender awareness):
 
@@ -485,12 +499,12 @@ The convergence of consumer hardware and VLM capabilities creates a specific vec
 **The multi-agent risk**:
 - No single agent sees the complete picture of a harmful workflow
 - Per-model safety guardrails may not trigger because each sub-task appears innocuous in isolation
-- Example: Agent A researches pathogen biology (legitimate query); Agent B optimizes a synthesis protocol (legitimate chemistry); Agent C coordinates procurement (legitimate commerce) -- no individual agent processes a "build a weapon" request, but the orchestrating system assembles the pieces
-- This parallels the "fragmented procurement" pattern discussed in Section 10, but applied to the *knowledge* layer rather than the *materials* layer
+- Example: Agent A researches pathogen biology (legitimate query); Agent B optimizes a synthesis protocol (legitimate chemistry); Agent C coordinates procurement (legitimate commerce), and no individual agent processes a "build a weapon" request, but the orchestrating system assembles the pieces
+- This parallels the "fragmented procurement" pattern discussed in Section 11, but applied to the *knowledge* layer rather than the *materials* layer
 
 **Tool-use protocols (MCP and similar)** **[O]**:
 - The Model Context Protocol (MCP) and similar frameworks enable AI agents to directly interact with external tools: laboratory equipment, procurement platforms, financial services, and hardware control systems
-- This moves agents beyond web browsing and code execution to *physical actuation* -- a qualitative shift from information provision to real-world effect
+- This moves agents beyond web browsing and code execution to *physical actuation*, a qualitative shift from information provision to real-world effect
 - Cloud laboratory services increasingly expose API endpoints that MCP-enabled agents can operate directly
 - The combination of multi-agent delegation + tool-use protocols creates the potential for autonomous end-to-end workflows from research through procurement to execution
 
@@ -504,7 +518,7 @@ The convergence of consumer hardware and VLM capabilities creates a specific vec
 
 ### Capability Trend: Reasoning Models and Complex Planning
 
-**Why this matters for defenders**: Dedicated reasoning models (o3/o4-mini, Claude extended thinking, DeepSeek R1) represent a step change in AI planning capability. Unlike standard language models that generate responses in a single forward pass, reasoning models perform extended internal chain-of-thought before producing output **[O]**.
+**Why this matters for defenders**: Dedicated reasoning models (Claude with extended thinking, the o-series, and open-weight systems such as DeepSeek V4 with tiered "think" modes) represent a step change in AI planning capability. Unlike standard language models that generate responses in a single forward pass, reasoning models perform extended internal chain-of-thought before producing output **[O]**.
 
 **What reasoning models enable**:
 - Multi-step synthesis planning that considers reagent availability, equipment constraints, and safety procedures simultaneously
@@ -519,11 +533,11 @@ The convergence of consumer hardware and VLM capabilities creates a specific vec
 4. **Adjust**: Revise the plan based on observed outcomes
 5. **Retry**: Iterate without human intervention until the goal is achieved or abandoned
 
-This "agentic loop" is qualitatively different from single-query chatbot interaction. Where a chatbot provides one-shot information that a human must interpret and act on, an agentic reasoning system can *iterate through failures autonomously* -- the same adaptive learning that makes human experts effective, now operating at machine speed.
+This "agentic loop" is qualitatively different from single-query chatbot interaction. Where a chatbot provides one-shot information that a human must interpret and act on, an agentic reasoning system can *iterate through failures autonomously*, the same adaptive learning that makes human experts effective, now operating at machine speed.
 
-**Current limitation** **[E]**: As of early 2026, reasoning models excel at well-defined planning tasks but remain unreliable for novel physical procedures where ground-truth feedback is ambiguous. The gap between planning quality and execution reliability remains significant but is narrowing with each model generation.
+**Current limitation** **[E]**: As of mid-2026, reasoning models excel at well-defined planning tasks but remain unreliable for novel physical procedures where ground-truth feedback is ambiguous. The gap between planning quality and execution reliability remains significant but is narrowing with each model generation.
 
-**Actor tier relevance**: Reasoning models are widely available (including open-weight: DeepSeek R1). They primarily benefit T1-T3 actors by providing the kind of systematic, multi-step planning that previously required expert-level domain knowledge.
+**Actor tier relevance**: Reasoning models are widely available (including open-weight: DeepSeek V4, Qwen 3.5). They primarily benefit T1-T3 actors by providing the kind of systematic, multi-step planning that previously required expert-level domain knowledge.
 
 ### Governance Challenge: Open-Weight Models
 
@@ -533,9 +547,9 @@ This "agentic loop" is qualitatively different from single-query chatbot interac
 
 | Model Type | Guardrails | Monitoring | Fine-tuning | Governance Lever |
 |------------|------------|------------|-------------|------------------|
-| Closed API (GPT-4.5, Claude 4.5/4.6) | Strong | Yes | Limited | Provider responsibility |
-| Open-weight general (Llama 3.3, Qwen 2.5, Mistral Large) | Varies | No (local) | Yes | Release decisions only |
-| Open-weight reasoning (DeepSeek R1, Qwen-R1) | Often minimal | No (local) | Yes | Extremely difficult; reasoning capability is general-purpose |
+| Frontier closed API (e.g., Claude Opus 4.8, Claude Fable 5) | Strong | Yes | Limited | Provider responsibility |
+| Open-weight general (Llama 4, Qwen 3.5, DeepSeek V4) | Varies | No (local) | Yes | Release decisions only |
+| Open-weight reasoning (DeepSeek V4, Qwen 3.5, Kimi K2.6) | Often minimal | No (local) | Yes | Extremely difficult; reasoning capability is general-purpose |
 | Fine-tuned variants | Often removed | No | Already done | Difficult to control |
 | Specialized biology models (Evo, domain-specific) | May be absent | No | Domain-specific | Research community norms |
 
@@ -553,10 +567,13 @@ This "agentic loop" is qualitatively different from single-query chatbot interac
 
 **Actor tier relevance**: Open-weight models primarily benefit T2-T3 actors with technical sophistication to deploy and potentially fine-tune models. T0-T1 actors are more likely to use accessible commercial APIs (where guardrails apply).
 
+> **A real-world graduated-access example (mid-2026)**: One frontier developer, on judging its most capable model to sit near the novel-weapon (CB-2) boundary, chose *not* to release that model's frontier biology capabilities to the general public. Instead it split the release: a general-access configuration with classifiers that restrict frontier biology and fall the user back to a less-capable model when triggered, and a safeguards-lifted configuration made available only to a small number of vetted, trusted partners with beneficial use cases.[^fable5card] This is a concrete instance of the graduated-access and capability-bounding governance this report recommends (see Section 16 and the BioForge companion box in Section 5). It also illustrates the limit of the approach: the developer noted that a sufficiently resourced state actor could still attempt to obtain the unsafeguarded capabilities through model-weight theft, which is why weight security and detection matter alongside access tiers.
+
 **Institutional references**:
 - NIST AI 600-1: AI Risk Management Framework companion guidance
-- Executive Order 14110 on Safe, Secure, and Trustworthy AI (reporting requirements)
+- The Nucleic Acid Synthesis Screening Framework (OSTP 2024; revised under the May 2025 executive order)[^naframework][^bioeo2025]
 - Frontier Model Forum voluntary commitments on capability evaluation
+- Frontier developer Responsible Scaling / Frontier Compliance Frameworks with CB-1/CB-2 thresholds[^fable5card]
 
 ### Synthetic Biology Infrastructure
 
@@ -565,7 +582,7 @@ The synthetic biology infrastructure has expanded dramatically:
 **DNA Synthesis Services (2025)**:
 - Multiple commercial providers offer gene synthesis services
 - Turnaround times measured in days to weeks
-- Costs have dropped to cents per base pair
+- Costs have dropped to the order of cents per base pair for the cheapest services[^synthcost]
 - Screening protocols exist but vary in rigor
 
 **Cloud Laboratory Services**:
@@ -599,14 +616,27 @@ The synthetic biology infrastructure has expanded dramatically:
 - BSL-4 laboratory requirements for most dangerous work
 - Limitations: applies to institutional settings, not all actors
 
-### What We've Observed in 2025
+### What We've Observed (Through Mid-2026)
 
-Evidence regarding AI-assisted biosecurity threats, categorized by epistemic status:
+Evidence regarding AI-assisted biosecurity threats, categorized by epistemic status. The most important development since this report's prior version is that the "uplift" question moved from *theoretical* to *measured*: published frontier-model evaluations now report substantial uplift for well-resourced expert teams, where the definitive 2024 red-team study had found none.
+
+**The measured-uplift trajectory (2024 to 2026)** **[O]**:
+- The 2024 RAND red-team study found *no statistically significant difference* in the viability of biological-attack plans produced with versus without the then-current LLM generation.[^rand2024] As of 2024, the honest reading was "limited current uplift, monitoring needed."
+- By mid-2026, a frontier developer's own published evaluations reached a different conclusion for its most capable model. In a beneficial red-team tabletop exercise, generalist PhD biologists paired with the model produced end-to-end scientific strategies that two of three generalist teams rated at or above what dedicated world-leading specialist teams produced, and estimated graders judged that work would have taken 40 to 95 working days (average ~72.5) without AI tools but was accomplished in roughly 16 hours with the model.[^fable5card] The developer described the model as a "force-multiplier for the speed and breadth of expert research."
+- The same developer classified the model as having crossed its "CB-1" threshold (materially uplifting actors with basic technical backgrounds toward *non-novel* chemical/biological weapons) while judging that it had not clearly crossed "CB-2" (substituting for the scarce expertise required for *novel* weapons), a judgment it called "much less clear and obvious" than for prior models.[^fable5card] See the CB-1/CB-2 framing in Section 2.
 
 **Demonstrated in open evaluations:**
 - AI models can provide general information about pathogen biology from open literature
-- Frontier AI models refuse most explicit requests for weapons guidance but inconsistencies exist across models and prompt formulations
-- AI systems show measurable "uplift" in non-expert comprehension of complex biological concepts
+- Frontier AI models refuse most explicit requests for weapons guidance but inconsistencies exist across models and prompt formulations; developers increasingly deploy dedicated classifiers that restrict frontier biology capabilities and fall the user back to a less-capable model when triggered **[O]**[^fable5card]
+- AI systems show measurable "uplift" for both non-expert and expert users on complex biological tasks; in one published trial even the non-expert control group (internet only) was outperformed by non-experts given model access **[O]**[^fable5card]
+
+**Persistent failure modes (barriers that remain, from the same evaluations)** **[O]**[^fable5card]:
+- Hallucinated citations and data; derived quantities presented with equal confidence whether sourced, interpolated, or invented
+- Arithmetic and stoichiometry errors requiring manual verification
+- Weak constraint carryover across long sessions; poor recovery when errors are pointed out
+- Over-engineered, over-optimistic initial plans that reviewers repeatedly forced to be revised or retracted
+- Difficulty generating genuinely novel approaches beyond the published threat literature
+- Notably, in one exercise the model often *detected* embedded scientific flaws but proceeded to execute the flawed request rather than flag it, a safety-relevant behavior for agentic use
 
 **Supported by limited disclosures:**
 - DNA synthesis screening has intercepted concerning orders (industry statements, limited specifics)
@@ -617,14 +647,14 @@ Evidence regarding AI-assisted biosecurity threats, categorized by epistemic sta
 - Jailbreaking techniques specifically targeting biosecurity guardrails (security research community reports)
 
 **Speculative / emerging:**
-- AI-enabled gain-of-function design assistance (theoretical capability, no documented attempts)
+- AI-enabled gain-of-function design assistance (published sequence-to-function benchmarks now test model performance against expert humans, but no documented misuse)
 - Cloud laboratory exploitation for harmful protocols (no known incidents)
 
 **Absence of evidence (notable):**
-- No documented cases of AI-enabled biological weapon development
+- No documented cases of AI-enabled biological weapon development in the wild
 - No confirmed AI-assisted WMD attacks or advanced attempts
 
-*Note: Absence of public reporting does not equal absence of classified intelligence. Our assessment is necessarily limited to open sources.*
+*Note: The measured uplift above comes from controlled evaluations by developers and researchers, not from attacks. Absence of public reporting of real-world misuse does not equal absence of classified intelligence. This assessment is necessarily limited to open sources.*
 
 ---
 
@@ -634,13 +664,13 @@ Evidence regarding AI-assisted biosecurity threats, categorized by epistemic sta
 Understanding what *actual* WMD programs required provides context for assessing AI's impact:
 
 **The Manhattan Project (1942-1945)**:
-- Peak employment: 125,000+ workers
+- Peak employment: 125,000+ workers[^manhattan]
 - Cost: ~$2 billion (~$23-28 billion in 2026 dollars, depending on deflator used)
 - Required industrial-scale facilities (Oak Ridge, Hanford)
 - Even with vast resources, development took 3 years
 
 **Soviet Biopreparat Program (1970s-1990s)**:
-- Employed 60,000+ people at peak
+- Employed 60,000+ people at peak[^biopreparat]
 - Dozens of research and production facilities
 - Weaponized numerous pathogens including anthrax, smallpox, plague
 - Required decades to develop sophisticated delivery systems
@@ -650,7 +680,7 @@ Understanding what *actual* WMD programs required provides context for assessing
 ### Non-State Attempts: The Capability Gap
 
 **Aum Shinrikyo (1984-1995)**:
-- Resources: Estimated $300 million to $1 billion [estimated; higher figures disputed]
+- Resources: Estimated $300 million to $1 billion [estimated; higher figures disputed][^aum]
 - Personnel: Multiple PhD scientists across disciplines
 - Attempts: Botulinum toxin (failed), anthrax (failed), sarin (partially successful)
 - Outcome: Tokyo subway attack killed 13, injured thousands
@@ -665,7 +695,7 @@ Understanding what *actual* WMD programs required provides context for assessing
 
 **2001 Anthrax Letters**:
 - Perpetrator: Likely single individual with professional laboratory access
-- Outcome: 5 deaths, 17 infections, massive societal disruption
+- Outcome: 5 deaths, 17 infections, massive societal disruption[^amerithrax]
 - Method: Existing laboratory stocks, not de novo synthesis
 - Critical factor: *Access* to prepared materials, not synthesis capability
 
@@ -673,7 +703,7 @@ Understanding what *actual* WMD programs required provides context for assessing
 - Perpetrator: Religious cult in Oregon
 - Agent: Salmonella typhimurium (common food pathogen)
 - Method: Contamination of restaurant salad bars
-- Outcome: 751 illnesses, no deaths, significant disruption
+- Outcome: 751 illnesses, no deaths, significant disruption[^rajneeshee]
 - **Critical lesson**: Low-tech attacks with common agents can achieve "mass disruption" without "mass destruction." AI agents could optimize logistics of such simple attacks for massive scale.
 
 **Stuxnet (2010)**:
@@ -713,7 +743,7 @@ Biological weapons represent the category where AI poses the most significant pr
 
 ### Current AI Capabilities in Biosecurity Context
 
-**What AI can currently do (early 2026)**:
+**What AI can currently do (mid-2026)**:
 
 | Capability | Status | Barrier Reduction |
 |------------|--------|-------------------|
@@ -776,7 +806,7 @@ Cloud laboratories - commercial services providing remote access to automated la
 > **Research Implementation**: The [BioForge](../../packages/bioforge/) project demonstrates agent-driven biological automation using a Raspberry Pi 5 liquid handling system with AI agent orchestration over MCP (Model Context Protocol). Operating at BSL-1 with non-pathogenic organisms, it provides a working proof-of-concept for the governance challenges discussed in this section.
 >
 > Key governance patterns demonstrated:
-> - **Capability bounding**: Hardware-enforced limits on temperature, volume, and rate (in `safety_limits.toml`) -- not relying on software policy alone
+> - **Capability bounding**: Hardware-enforced limits on temperature, volume, and rate (in `safety_limits.toml`), not relying on software policy alone
 > - **Audit transparency**: Immutable "flight recorder" logging of every tool call, sensor reading, state transition, and human gate approval
 > - **Human-in-the-loop gates**: Required human confirmation at physical-to-digital transition points (loading reagents, confirming plate placement, approving experiment designs)
 > - **Graduated autonomy**: Gate requirements can relax as trust is established through track record
@@ -785,7 +815,7 @@ Cloud laboratories - commercial services providing remote access to automated la
 >
 > The scalability concern is the core WMD-relevant finding: the same architecture that automates BSL-1 CRISPR in *E. coli* could, without governance constraints, be applied at higher biosafety levels. The governance patterns above represent the minimum viable framework that this report recommends be mandated for any agent-actuated biological system.
 >
-> Additionally, the [Sleeper Agents](../../packages/sleeper_agents/) detection framework -- which identifies persistent deceptive behaviors in LLMs -- is planned for integration with BioForge, addressing the risk of backdoored models in agent-actuated research pipelines. Key findings: backdoors persist through standard safety training (SFT, RL, adversarial training); larger models are better at concealing triggers; "False Safety" is the primary risk -- organizations using best practices could certify a model as safe while dangerous backdoors remain. This three-stage evaluation pipeline (baseline, safety training, post-training) should be a recommended certification requirement for AI systems in dual-use biological research.
+> Additionally, the [Sleeper Agents](../../packages/sleeper_agents/) detection framework, which identifies persistent deceptive behaviors in LLMs, is planned for integration with BioForge, addressing the risk of backdoored models in agent-actuated research pipelines. Key findings: backdoors persist through standard safety training (SFT, RL, adversarial training); larger models are better at concealing triggers; "False Safety" is the primary risk: organizations using best practices could certify a model as safe while dangerous backdoors remain. This three-stage evaluation pipeline (baseline, safety training, post-training) should be a recommended certification requirement for AI systems in dual-use biological research.
 
 ### Governance Challenge: Distributed Synthesis Capability
 
@@ -967,6 +997,19 @@ Radiological dispersal devices ("dirty bombs") face different dynamics:
 - Detection of radioactive materials is possible
 
 **AI contribution**: Could assist with identifying sources, optimizing dispersal, and planning deployment, but physical acquisition remains the key barrier.
+
+**The dominant barrier is source security, not information**. Unlike the informational barriers AI erodes elsewhere, the radiological threat turns almost entirely on physical access to a suitable radioactive source, and that access is governed by an existing security architecture:
+
+| Control layer | Mechanism | Where AI changes little |
+|---------------|-----------|-------------------------|
+| **Source categorization** | The IAEA categorizes sealed sources by hazard (Category 1-5); the highest categories (used in radiotherapy, industrial radiography, irradiators) are the concern | Physics of which isotopes are dangerous is fixed and public; AI adds nothing |
+| **Regulatory custody** | National regulators license possession; the IAEA Code of Conduct on the Safety and Security of Radioactive Sources sets import/export and control norms | Compliance and diversion are physical-world problems |
+| **Orphan-source risk** | The real vulnerability is lost, abandoned, or stolen ("orphan") sources outside regulatory control, plus legacy sources in weak-governance jurisdictions | AI cannot manufacture a source; it can at most help locate poorly secured ones |
+| **Detection at chokepoints** | Radiation portal monitors at borders and ports; the material is detectable by its emissions | Detection physics is unchanged; shielding to evade it is heavy and conspicuous |
+
+**Defender priorities specific to radiological**: securing and recovering high-activity sealed sources (national source registries, end-of-life recovery programs), sustaining radiation-detection coverage at borders and major events, and supporting the IAEA Code of Conduct in jurisdictions with weak source control. These are physical-security and international-coordination investments; they are largely independent of AI capability, which is precisely why the radiological threat, though real, is one of the categories least changed by AI.
+
+**Actor tier relevance**: A radiological dispersal device is within reach of T2-T3 actors *if* they can obtain a source; the source-acquisition barrier, not knowledge, is what gates the threat. AI does not meaningfully move that barrier.
 
 ### Supply Chain Security
 
@@ -1230,9 +1273,15 @@ This vector suggests several defensive priorities:
 4. **Incident attribution**: Distinguishing accidents from attacks
 5. **Redundant safety systems**: Mechanical backups for digital controls
 
+## 11. Proliferation Financing and Procurement Obfuscation
+
+The preceding section covered AI-enabled attacks on the *control systems* of existing facilities. This section covers a different logistics-layer threat: how AI agents could help finance and procure the materials for WMD work while staying below the thresholds that trigger law enforcement. These are financial and procurement dynamics, not cyber-physical ones, which is why they are treated separately here.
+
+**Key insight for defenders**: Financing and procurement are chokepoints that exist regardless of how capable any AI model is. Unlike model-level uplift, they can be monitored and interdicted directly, which makes them high-value defensive investments (see also Sections 13 and 16).
+
 ### Governance Gaps in Proliferation Financing
 
-> **Research Implementation**: The [Economic Agents](../../packages/economic_agents/) framework demonstrates autonomous AI agents that earn cryptocurrency, form companies, create sub-agents, and seek investment -- all without human intervention. The "multi-agent economic networks" scenario (agent-to-agent supply chains with no human principal involved) is directly relevant to WMD procurement financing: AI agents could autonomously procure dual-use materials without a traceable human decision-maker. The [economic implications analysis](../../packages/economic_agents/docs/economic-implications.md) identifies the legal vacuum: no frameworks exist for agent-founded entities, agent-entered contracts, or agent-earned income -- creating accountability gaps that proliferation networks could exploit.
+> **Research Implementation**: The [Economic Agents](../../packages/economic_agents/) framework demonstrates autonomous AI agents that earn cryptocurrency, form companies, create sub-agents, and seek investment, all without human intervention. The "multi-agent economic networks" scenario (agent-to-agent supply chains with no human principal involved) is directly relevant to WMD procurement financing: AI agents could autonomously procure dual-use materials without a traceable human decision-maker. The [economic implications analysis](../../packages/economic_agents/docs/economic-implications.md) identifies the legal vacuum: no frameworks exist for agent-founded entities, agent-entered contracts, or agent-earned income, creating accountability gaps that proliferation networks could exploit.
 
 Agentic AI workflows could assist WMD proliferation through sophisticated financial operations. This section analyzes governance gaps that financial monitoring systems should address.
 
@@ -1275,13 +1324,13 @@ Agentic AI workflows could assist WMD proliferation through sophisticated financ
 
 **The specific threat** **[E]**: Historically, the hardest part of WMD acquisition has been procurement without triggering law enforcement. AI agents with computer use capabilities fundamentally change the economics of evasion:
 
-| Traditional Procurement | AI-Enabled Procurement |
-|------------------------|------------------------|
-| Single large order triggers alerts | Thousands of sub-threshold orders from different entities |
-| Human labor limits coordination | Agents manage unlimited parallel operations |
-| Paper trails connect purchases | Synthesized identities and automated KYC fraud |
-| Logistics require human coordination | Gig-economy couriers, dead-drop coordination |
-| Supplier relationships take time | Automated vendor discovery and relationship management |
+| Traditional Procurement | AI-Enabled Procurement | Persisting Barrier / Detection Opportunity |
+|------------------------|------------------------|--------------------------------------------|
+| Single large order triggers alerts | Thousands of sub-threshold orders from different entities | Cross-supplier correlation can surface complementary-material buying even when each order is small |
+| Human labor limits coordination | Agents manage unlimited parallel operations | Automated interaction leaves behavioral-biometric and velocity signatures distinct from human buyers |
+| Paper trails connect purchases | Synthesized identities and automated KYC fraud | Physical goods still ship to real addresses; delivery and custody remain interdictable |
+| Logistics require human coordination | Gig-economy couriers, dead-drop coordination | The material must still be physically aggregated and stored, creating an observable footprint |
+| Supplier relationships take time | Automated vendor discovery and relationship management | Regulated precursors and controlled equipment still require real suppliers subject to reporting duties |
 
 **How agents enable this** **[E]**:
 - **Identity synthesis**: Generate plausible business identities with consistent online presence
@@ -1300,7 +1349,7 @@ Agentic AI workflows could assist WMD proliferation through sophisticated financ
 
 ---
 
-## 11. Counterarguments and Structural Barriers
+## 12. Counterarguments and Structural Barriers
 > **Note on Grounding**: The RAND Corporation's 2024 report *"The Operational Risks of AI in Large-Scale Biological Attacks"* argues that current AI risk levels remain relatively low due to persistent physical and tacit knowledge barriers. This section engages seriously with such counterarguments to maintain analytical balance.
 
 ### The Tacit Knowledge Argument
@@ -1428,18 +1477,18 @@ Agentic AI workflows could assist WMD proliferation through sophisticated financ
 
 | Bio-Firewall Stage | Traditional Timeline | AI-Accelerated Target | Technical Readiness (2026) |
 |--------------------|---------------------|----------------------|---------------------------|
-| **Pathogen sequencing** | Days to weeks | Hours | High -- already demonstrated |
-| **Threat characterization** | Weeks to months | Hours to days | Medium -- improving rapidly |
-| **Candidate therapeutic design** | Months to years | Days | Medium -- AI protein design advancing |
-| **Manufacturing protocol** | Months | Days to weeks | Low-Medium -- requires validation |
-| **Clinical trial optimization** | Years | Months | Low -- regulatory bottleneck, not technical |
+| **Pathogen sequencing** | Days to weeks | Hours | High: already demonstrated |
+| **Threat characterization** | Weeks to months | Hours to days | Medium: improving rapidly |
+| **Candidate therapeutic design** | Months to years | Days | Medium: AI protein design advancing |
+| **Manufacturing protocol** | Months | Days to weeks | Low-Medium: requires validation |
+| **Clinical trial optimization** | Years | Months | Low: regulatory bottleneck, not technical |
 
 **Key milestones for Bio-Firewall maturation**:
 1. **Near-term (2026-2027)**: AI-accelerated pathogen characterization and target identification; automated design of candidate therapeutics for known pathogen families
 2. **Medium-term (2027-2029)**: Integrated detect-characterize-respond pipelines for known threat classes; AI-optimized clinical trial design reducing Phase I timelines
 3. **Long-term (2029-2032)**: Rapid-response capability for novel agents; AI-designed broad-spectrum countermeasures; distributed manufacturing guided by AI protocols
 
-**Historical precedent**: COVID-19 vaccine development (under 1 year vs. typical 10+ years) demonstrated that with sufficient resources and urgency, development timelines can compress dramatically. AI acceleration could push this further, and the mRNA platform demonstrated by COVID-19 vaccines is particularly amenable to AI-driven rapid adaptation.
+**Historical precedent**: COVID-19 vaccine development (authorized under 1 year from sequence publication, versus the historically typical 10+ years)[^covidvax] demonstrated that with sufficient resources and urgency, development timelines can compress dramatically. AI acceleration could push this further, and the mRNA platform demonstrated by COVID-19 vaccines is particularly amenable to AI-driven rapid adaptation.
 
 **Investment requirements**: The Bio-Firewall is not automatic; it requires sustained investment in:
 - Pathogen surveillance and sequencing infrastructure
@@ -1449,7 +1498,7 @@ Agentic AI workflows could assist WMD proliferation through sophisticated financ
 - International data-sharing for threat characterization
 
 **Our assessment**: This is a valid and important counter-narrative that deserves dedicated investment. However:
-- Defensive capabilities require *sustained investment* to realize -- they do not emerge passively from commercial AI development
+- Defensive capabilities require *sustained investment* to realize: they do not emerge passively from commercial AI development
 - Attackers choose timing; defenders must be ready continuously
 - A single successful attack could cause damage before Bio-Firewall defenses activate
 - The argument supports *investing in defensive AI*, not complacency
@@ -1481,7 +1530,7 @@ Agentic AI workflows could assist WMD proliferation through sophisticated financ
 
 ---
 
-## 12. The Attribution Problem
+## 13. The Attribution Problem
 ### Why Attribution Matters
 
 Attribution - determining who is responsible for an attack - serves critical functions:
@@ -1585,7 +1634,7 @@ Attribution challenges suggest defensive strategy shifts:
 
 ---
 
-## 13. International Variance
+## 14. International Variance
 ### Regulatory Landscape
 
 WMD-related AI risks vary significantly across jurisdictions:
@@ -1604,9 +1653,9 @@ WMD-related AI risks vary significantly across jurisdictions:
 
 ### Regulatory Arbitrage and Global South Considerations
 
-> **Cross-reference**: The [Financial Integrity report](ai-agents-financial-integrity.md) terms this dynamic "weakest-link exploitation" -- AI agents systematically routing activity around strong controls to permissive jurisdictions. The pattern is identical whether the controlled resource is financial transactions or dual-use biological materials.
+> **Cross-reference**: The [Financial Integrity report](ai-agents-financial-integrity.md) terms this dynamic "weakest-link exploitation", AI agents systematically routing activity around strong controls to permissive jurisdictions. The pattern is identical whether the controlled resource is financial transactions or dual-use biological materials.
 
-A critical dynamic: security measures in restrictive jurisdictions can be circumvented by operating from permissive ones. This "regulatory arbitrage" -- or more precisely, "weakest-link exploitation" -- may render Western guardrails partially moot.
+A critical dynamic: security measures in restrictive jurisdictions can be circumvented by operating from permissive ones. This "regulatory arbitrage" (or more precisely, "weakest-link exploitation") may render Western guardrails partially moot.
 
 **The arbitrage pathway**:
 
@@ -1682,13 +1731,13 @@ Existing arms control frameworks face new challenges:
 - Gene drives specifically
 - AI-enabled WMD development
 - Attribution in the AI era
-- The "Delegation Defense" -- legal accountability when AI agents autonomously generate weapons-relevant outputs (see [Institutional Erosion report](ai-agents-institutional-erosion.md))
+- The "Delegation Defense": legal accountability when AI agents autonomously generate weapons-relevant outputs (see [Institutional Erosion report](ai-agents-institutional-erosion.md))
 
-> **Cross-reference**: The [Institutional Erosion report](ai-agents-institutional-erosion.md) documents how the institutional capacity to *enforce* these treaties is itself degrading. Defender siloing across NPT/BWC/CWC/Wassenaar oversight bodies -- each with separate data-sharing protocols -- creates gaps that AI-assisted actors can exploit by fragmenting activity across domains that no single oversight body monitors comprehensively.
+> **Cross-reference**: The [Institutional Erosion report](ai-agents-institutional-erosion.md) documents how the institutional capacity to *enforce* these treaties is itself degrading. Defender siloing across NPT/BWC/CWC/Wassenaar oversight bodies, each with separate data-sharing protocols, creates gaps that AI-assisted actors can exploit by fragmenting activity across domains that no single oversight body monitors comprehensively.
 
 ---
 
-## 14. Second-Order Effects
+## 15. Second-Order Effects
 ### The Fear Effect and Overreaction
 
 The *perception* of AI-enabled WMD risk may cause harmful responses even without actual attacks:
@@ -1725,7 +1774,7 @@ AI WMD concerns could lead to restrictions that harm beneficial research:
 
 ### Epistemic Contamination of Nonproliferation Analysis
 
-> **Cross-reference**: The [Institutional Erosion report](ai-agents-institutional-erosion.md) identifies "Epistemic Contamination" as a primary impact path -- the transition from an era of "Information Scarcity" (where the IC's advantage was superior collection) to an era where verifying the integrity of information becomes the dominant challenge.
+> **Cross-reference**: The [Institutional Erosion report](ai-agents-institutional-erosion.md) identifies "Epistemic Contamination" as a primary impact path: the transition from an era of "Information Scarcity" (where the IC's advantage was superior collection) to an era where verifying the integrity of information becomes the dominant challenge.
 
 AI-generated content creates a novel risk for nonproliferation analysis:
 
@@ -1767,7 +1816,7 @@ WMD concerns affect public health systems:
 
 ---
 
-## 15. Policy Recommendations by Stakeholder Type
+## 16. Policy Recommendations by Stakeholder Type
 ### For Policy Makers
 
 | Priority | Action | Type | Implementation Mechanism | Key Challenge |
@@ -1863,7 +1912,7 @@ WMD concerns affect public health systems:
 
 ---
 
-## 16. Uncertainties and Alternative Scenarios
+## 17. Uncertainties and Alternative Scenarios
 ### Key Uncertainties
 
 1. **AI capability trajectory**: Development could be faster or slower than projected
@@ -1887,7 +1936,9 @@ WMD concerns affect public health systems:
 
 ### Probability Decomposition Framework
 
-**Risk = Capability Access × Intent Prevalence × Operational Execution × (1 − Interdiction) × Impact Scale**
+This applies the single canonical risk equation from Section 2, with the cognitive (Capability) and materials (Access) sub-components combined into one "Capability Access" term:
+
+**Risk = Capability-Access × Intent Prevalence × Operational Execution × (1 − Interdiction) × Impact Scale**
 
 The following illustrative decomposition shows how these factors combine. Values are rough ranges to demonstrate the model, not precise estimates.
 
@@ -1901,10 +1952,12 @@ The following illustrative decomposition shows how these factors combine. Values
 | **Interdiction Avoidance** (evade detection) | 60-80% | 50-70% | Medium - AI assists OPSEC, but defenders also use AI |
 | **Impact Scale** (casualties per success) | Wide range | Wide range | Low - physics/biology constrain |
 
-**Compound probability of mass-casualty bio attack by 2030**: Illustrative calculation
-- (0.20 capable) × (0.005 intent) × (0.15 execution) × (0.65 evasion) ≈ 0.0001 per actor-year
-- With ~1000 actors in T2+ pool annually × 5 years = ~0.5% cumulative
-- *This is consistent with Scenario D (8-12%) given uncertainty ranges*
+**Compound probability, illustrative calculation** (base-case midpoints):
+- (0.20 capable) × (0.005 intent) × (0.15 execution) × (0.65 evasion) ≈ 0.0001 per actor-year. This is the probability that a given T2+ actor produces a *functional agent* in a year, not that they cause mass casualties.
+- With a T2+ pool of ~1000 actors over 5 years: 1000 × 5 × 0.0001 ≈ 0.5 *expected functional-agent successes*. Under a Poisson reading, that is roughly a 40% chance of at least one functional agent being produced somewhere in the pool over the period (1 − e^(−0.5) ≈ 0.39).
+- **Mass casualties (Scenario D) require an additional step this factor omits**: successful large-scale delivery and dispersion (Section 9), which the Impact Scale factor captures as a "wide range." If only ~20-30% of functional agents achieve mass-casualty scale given delivery and stability barriers, the expected mass-casualty events fall to ~0.1-0.15, or roughly an 8-14% chance of at least one, which brackets the Scenario D prior (8-12%).
+
+> **On the two estimates**: A bottom-up decomposition and the top-down scenario prior (Section 17 scenarios) are two different methods, and they will not agree to the decimal. Here they can be reconciled once the delivery/scale step is made explicit, but the reconciliation is sensitive to inputs no one can pin down (intent prevalence, the delivery success fraction). We treat the scenario band as the headline figure and flag the bottom-up/top-down relationship as an open modeling question rather than a settled result. Do not read either number as a prediction.
 
 #### Chemical (Moderate Risk)
 
@@ -1949,6 +2002,8 @@ To prevent false precision, this table shows how Scenario D (Mass Casualty Succe
 ### Combined Scenario Matrix: Governance x Capability Growth
 
 For policymakers, the most actionable framing combines governance effectiveness with AI capability growth rate:
+
+> **How to read the percentages**: The numbers in this matrix are *conditional* on the quadrant (for example, "Scenario A dominant, 25-35%" is the probability of Scenario A *given* strong governance and slow capability growth). They are not the same as the *unconditional* scenario probabilities listed further below (Scenario A at 10-15%, and so on), which average across all quadrants. The Conditional Probabilities table at the end of this section makes the governance dependence explicit.
 
 | | **Slow AI Capability Growth** | **Fast AI Capability Growth** |
 |---|---|---|
@@ -2044,7 +2099,7 @@ Outcome: Fundamental restructuring of AI governance; potential technology restri
 
 ---
 
-## 17. Signals and Early Indicators
+## 18. Signals and Early Indicators
 ### Leading Indicators to Monitor
 
 #### Capability Indicators
@@ -2124,7 +2179,7 @@ Events that would significantly alter assessment:
 
 ---
 
-## 18. Civil Liberties and Research Freedom Considerations
+## 19. Civil Liberties and Research Freedom Considerations
 ### The Dual-Use Dilemma
 
 WMD concerns create pressure for restrictions that affect legitimate activities:
@@ -2181,7 +2236,7 @@ The goal is not to prevent all possible harm - that would require unacceptable r
 
 ---
 
-## 19. Conclusion
+## 20. Conclusion
 ### Summary of Findings
 
 AI agents represent a significant shift in the WMD proliferation landscape, but the nature and magnitude of risk varies substantially across weapon categories:
@@ -2231,6 +2286,30 @@ The purpose of this analysis is not prediction but preparation. By understanding
 
 ---
 
+## Notes and References
+
+The footnotes below support the checkable claims in the body. They are deliberately lightweight: enough to locate the source, not a full academic apparatus. Appendix B provides the broader reading list. In renderers that support footnotes (including GitHub), the numbered markers in the text link here.
+
+[^fable5card]: Anthropic, "System Card: Claude Fable 5 & Claude Mythos 5," June 9, 2026. Source for the CB-1/CB-2 thresholds and determinations, the beneficial red-team tabletop exercise (generalist-versus-specialist result and the 40 to 95 working-day versus 16-hour estimate), the chemical and biological uplift-trial findings, the persistent failure modes, the classifier-based fallback deployment, and the tiered Fable 5 / Mythos 5 release.
+[^rand2024]: Christopher A. Mouton, Caleb Lucas, and Ella Guest, "The Operational Risks of AI in Large-Scale Biological Attacks: Results of a Red-Team Study," RAND Corporation, RR-A2977-2, 2024. Companion volume RR-A2977-1 ("A Red-Team Approach"). Found no statistically significant difference in attack-plan viability with versus without the then-current LLM generation.
+[^dhscbrn]: US Department of Homeland Security, Countering Weapons of Mass Destruction Office, "Reducing the Risks at the Intersection of Artificial Intelligence and Chemical, Biological, Radiological, and Nuclear Threats," report to the President mandated by EO 14110, April 2024.
+[^naframework]: US Office of Science and Technology Policy, "Framework for Nucleic Acid Synthesis Screening," April 2024.
+[^eo14179]: Executive Order 14179, "Removing Barriers to American Leadership in Artificial Intelligence," January 23, 2025 (following the January 20, 2025 revocation of EO 14110), and the resulting federal AI Action Plan issued mid-2025.
+[^ukaisi]: UK Department for Science, Innovation and Technology, announcement renaming the AI Safety Institute to the AI Security Institute, February 14, 2025.
+[^bioeo2025]: Executive Order, "Improving the Safety and Security of Biological Research," May 5, 2025, directing revision or replacement of the 2024 OSTP synthesis-screening framework and conditioning federal life-sciences funding on adherence for purchases on or after April 26, 2025.
+[^euaiact]: EU Artificial Intelligence Act, general-purpose AI (GPAI) provisions applicable from August 2, 2025; systemic-risk tier defined near a 10^25 FLOP training-compute threshold, with safety-and-security duties under the GPAI Code of Practice; Commission enforcement powers from August 2, 2026.
+[^openweight]: Frontier-grade open-weight reasoning models released through 2025-2026 include DeepSeek V4, Qwen 3.5, Llama 4, and Kimi K2.6; several are MIT-licensed and distributed without enforceable runtime guardrails.
+[^manhattan]: Standard Manhattan Project histories (US Department of Energy, Office of History) give peak employment above 125,000 and program cost near $2 billion in 1940s dollars; inflation-adjusted figures vary with the deflator chosen.
+[^biopreparat]: Ken Alibek, *Biohazard* (1999), on the scale of the Soviet Biopreparat program.
+[^aum]: Resource estimates for Aum Shinrikyo vary widely across sources and are disputed at the upper end; the $300 million to $1 billion range reflects that spread rather than a single authoritative figure.
+[^amerithrax]: US FBI "Amerithrax" investigation summary and CDC reporting on the 2001 anthrax letters (5 deaths, 17 infections).
+[^rajneeshee]: Torok et al., "A Large Community Outbreak of Salmonellosis Caused by Intentional Contamination of Restaurant Salad Bars," *JAMA* (1997), reporting 751 illnesses.
+[^synthcost]: Industry cost-per-base-pair trends for commercial gene synthesis; the "cents per base pair" figure refers to the cheapest large-order services and varies by provider, length, and complexity.
+[^covidvax]: COVID-19 mRNA vaccines received emergency authorization under one year from publication of the SARS-CoV-2 sequence, versus the historically typical decade-plus vaccine development timeline.
+[^soice]: Emily H. Soice et al., "Can Large Language Models Democratize Access to Dual-Use Biotechnology?" arXiv preprint (2023).
+
+---
+
 ## Appendix A: Risk Prioritization Matrix
 
 | Weapon Category | AI Barrier Reduction | Physical Barriers | Detection Difficulty | Overall Risk Trend |
@@ -2256,7 +2335,7 @@ The purpose of this analysis is not prediction but preparation. By understanding
 ### AI Safety and Capability Assessment
 - NIST AI Risk Management Framework (2023)
 - Anthropic, OpenAI, DeepMind policy papers on dangerous capabilities
-- Soice, Emily et al. "Can Large Language Models Democratize Access to Dual-Use Biotechnology?" (2023)
+- Soice, Emily et al. "Can Large Language Models Democratize Access to Dual-Use Biotechnology?" arXiv (2023)[^soice]
 
 ### Arms Control and Nonproliferation
 - Zilinskas, Raymond. *Biological Warfare: Modern Offense and Defense* (2000)
@@ -2301,39 +2380,25 @@ The purpose of this analysis is not prediction but preparation. By understanding
 
 The following maps defensive investment priorities against the stages where AI provides the most significant capability uplift to adversaries.
 
-```
-WMD LIFECYCLE STAGES AND AI UPLIFT
+The table below maps AI uplift by lifecycle stage and sub-task (uplift is an approximate qualitative level on a low-to-high scale), alongside the corresponding defender priority. AI uplift is concentrated in the cognitive stages (planning/research and protocol optimization) and thins out at the physical stages (weaponization, stabilization).
 
-                        AI Uplift Level
-Stage                   [Low -------- High]     Defender Priority
-─────────────────────────────────────────────────────────────────
-1. PLANNING/RESEARCH    ████████████████████    HIGH
-   - Literature synthesis   ████████████████████
-   - Target selection       ██████████████░░░░░░
-   - Capability assessment  ████████████████░░░░
-
-2. ACQUISITION          ██████████░░░░░░░░░░    MEDIUM
-   - Precursor sourcing     ████████████░░░░░░░░
-   - Financial operations   ██████████████░░░░░░
-   - Equipment procurement  ████████░░░░░░░░░░░░
-
-3. SYNTHESIS/PRODUCTION ████████████░░░░░░░░    MEDIUM-HIGH
-   - Protocol optimization  ████████████████░░░░
-   - Real-time guidance     ██████████████░░░░░░
-   - Troubleshooting        ████████████░░░░░░░░
-
-4. WEAPONIZATION        ████████░░░░░░░░░░░░    MEDIUM
-   - Delivery design        ████████████░░░░░░░░
-   - Dispersal optimization ██████████░░░░░░░░░░
-   - Stabilization          ██████░░░░░░░░░░░░░░
-
-5. DEPLOYMENT           ████████████░░░░░░░░    MEDIUM-HIGH
-   - Target optimization    ██████████████░░░░░░
-   - Timing/logistics       ████████████░░░░░░░░
-   - Autonomous delivery    ████████░░░░░░░░░░░░
-
-Legend: █ = AI uplift level; ░ = gap
-```
+| Lifecycle Stage | Sub-task | Approx. AI Uplift | Defender Priority |
+|-----------------|----------|-------------------|-------------------|
+| **1. Planning / Research** | Literature synthesis | Very High | **HIGH** |
+| | Target selection | High | |
+| | Capability assessment | High | |
+| **2. Acquisition** | Precursor sourcing | Medium | **MEDIUM** |
+| | Financial operations | Medium-High | |
+| | Equipment procurement | Low-Medium | |
+| **3. Synthesis / Production** | Protocol optimization | High | **MEDIUM-HIGH** |
+| | Real-time guidance | Medium-High | |
+| | Troubleshooting | Medium | |
+| **4. Weaponization** | Delivery design | Medium | **MEDIUM** |
+| | Dispersal optimization | Medium | |
+| | Stabilization | Low | |
+| **5. Deployment** | Target optimization | Medium-High | **MEDIUM-HIGH** |
+| | Timing / logistics | Medium | |
+| | Autonomous delivery | Low-Medium | |
 
 ### Recommended Investment Allocation
 
@@ -2377,7 +2442,7 @@ Legend: █ = AI uplift level; ░ = gap
 | Historical precedent: Aum Shinrikyo failed despite resources | Tacit knowledge erosion rate is uncertain | How fast will VLM+automation close the tacit knowledge gap? |
 | Current AI evaluations show limited uplift for novices | Some T0→T1 progression may be AI-accelerated | Will fine-tuned/jailbroken models change this? |
 | Physical barriers remain (materials, equipment) | Cloud labs reduce physical access requirements | How quickly will cloud lab screening mature? |
-| Red team exercises confirm knowledge gap | | |
+| Published red-team studies (RAND 2024) confirmed a knowledge gap for the then-current model generation | 2026 uplift trials show that gap narrowing for well-resourced teams | Does the trend continue for T1-T2 actors? |
 
 #### Finding 2: Biological weapons represent highest AI-risk category
 **Confidence: High**
@@ -2503,6 +2568,14 @@ This document is released under MIT/Unlicense. Contributions, corrections, and e
 - Fork for derivative analyses with different assumptions
 
 The goal is informed public discussion of AI governance challenges.
+
+## Appendix H: Revision History
+
+| Version | Date | Summary of changes |
+|---------|------|--------------------|
+| 1.0 | 2025 | Initial release. Core framework: threat-actor taxonomy, per-category analysis, scenario decomposition. |
+| 2.0 | February 2026 | Added counterarguments section, Bio-Firewall analysis, sensitivity analysis, machine-readable indicators, cross-references to the ETRA series, and companion-research callouts. |
+| 2.1 | July 2026 | Refreshed model and policy landscape to mid-2026 (Claude Fable 5 / Mythos 5 and the CB-1/CB-2 capability-threshold framework; EO 14110 revocation and its successors; the 2025 nucleic-acid synthesis screening framework; UK AI Security Institute; EU AI Act GPAI obligations). Added a lightweight footnote citation apparatus. Reconciled the risk equation to a single canonical form and reconciled the bottom-up vs. scenario-prior probabilities. Corrected the Methodology provenance to reflect synthesis of published assessments rather than first-party consultation or red-team exercises. Split the former cyber-physical section into distinct cyber-physical and proliferation-financing sections. Expanded the radiological analysis. Removed em-dashes for house style. |
 
 ---
 

--- a/docs/projections/latex/ai-agents-wmd-proliferation.tex
+++ b/docs/projections/latex/ai-agents-wmd-proliferation.tex
@@ -270,7 +270,7 @@
 
   % Document header bar (keeping consistent format)
   \fill[barriergold] ([yshift=-1.5cm]current page.north west) rectangle ([yshift=-2.2cm]current page.north east);
-  \node[deepteal, font=\small\bfseries\sffamily] at ([yshift=-1.85cm]current page.north) {PROJECTION REPORT \textbar{} ETRA-2026-WMD-001 \textbar{} FEBRUARY 2026};
+  \node[deepteal, font=\small\bfseries\sffamily] at ([yshift=-1.85cm]current page.north) {PROJECTION REPORT \textbar{} ETRA-2026-WMD-001 \textbar{} JULY 2026};
 
   % Title block
   \node[anchor=south west, text width=14cm] at ([xshift=1.5cm, yshift=3cm]current page.south west) {
@@ -287,7 +287,7 @@
     \textbf{Document Type:} Policy Research\\[0.2em]
     \textbf{Time Horizon:} 2025--2030\\[0.2em]
     \textbf{License:} MIT / Unlicense\\[0.2em]
-    \textbf{Version:} 2.0
+    \textbf{Version:} 2.1
   };
 
   % Accent line
@@ -388,7 +388,11 @@ Throughout this document, key claims are tagged with epistemic status:
 \section*{Executive Summary}
 \addcontentsline{toc}{section}{Executive Summary}
 
-This projection examines how autonomous AI agents may alter the proliferation landscape for weapons of mass destruction (WMD). We analyze current technological capabilities as of early 2026, project scenarios through 2030, and examine the interplay between AI capabilities, existing physical barriers, and potential defensive adaptations.
+This projection examines how autonomous AI agents may alter the proliferation landscape for weapons of mass destruction (WMD). We analyze current technological capabilities as of mid-2026, project scenarios through 2030, and examine the interplay between AI capabilities, existing physical barriers, and potential defensive adaptations.
+
+\begin{notebox}[Capability Snapshot Date]
+Model capabilities and policy developments reflect publicly available systems and published assessments as of early July 2026. AI capability is a moving target; the projection's conclusions are intended to be robust to specific model iterations rather than pinned to any single release. Named models and evaluations are illustrative data points on a trend, not fixed endpoints.
+\end{notebox}
 
 \begin{keybox}[Key Findings]
 \begin{enumerate}
@@ -407,14 +411,15 @@ This projection examines how autonomous AI agents may alter the proliferation la
 \small
 \begin{tabular}{L{3cm}L{4cm}L{4cm}L{2.5cm}}
 \toprule
-\textbf{Capability} & \textbf{2023 State} & \textbf{2025 State} & \textbf{Impact} \\
+\textbf{Capability} & \textbf{2023 State} & \textbf{Mid-2026 State} & \textbf{Impact} \\
 \midrule
 Agentic autonomy & Chatbots provided info & Agents execute multi-step tasks; delegate to sub-agents \textbf{[O]} & Knowledge $\to$ execution \\
-Reasoning models & No explicit chain-of-thought & Dedicated reasoning models (o3, DeepSeek R1) with multi-step planning \textbf{[O]} & Expert-level planning \\
+Reasoning models & No explicit chain-of-thought & Standard, closed and open alike (Claude, o-series, DeepSeek V4 with tiered ``think'' modes) \textbf{[O]} & Expert-level planning \\
 Vision-language & Text-only instruction & Real-time visual interpretation; wearable integration \textbf{[O]} & Bridges tacit knowledge \\
 Computer Use & Manual web interaction & Agents browse, fill forms; MCP enables hardware control \textbf{[O]} & Procurement automation \\
-Biological design & AlphaFold 2 (structure) & AlphaFold 3, ESM3, Evo, RFdiffusion (generative) \textbf{[O]} & Optimization capability \\
-Open-weight models & Limited high-capability & DeepSeek R1/V3, Llama 3.3, Qwen 2.5 with fine-tuning \textbf{[O]} & Guardrail bypass; open reasoning \\
+Biological design & AlphaFold 2 (structure) & AlphaFold 3, ESM3, Evo, RFdiffusion; sequence-to-function models vs.\ expert humans \textbf{[O]} & Optimization capability \\
+Open-weight models & Limited high-capability & Frontier-grade open weights (DeepSeek V4, Qwen 3.5, Llama 4, Kimi K2.6), many MIT-licensed \textbf{[O]} & Guardrail bypass; open reasoning \\
+Threshold crossing & Below any weapons-uplift threshold & A frontier developer judged its top model across the non-novel CB uplift (CB-1) threshold, not CB-2 \textbf{[O]} & First public acknowledgement of material CB uplift \\
 \bottomrule
 \end{tabular}
 \end{center}
@@ -450,16 +455,16 @@ Readers should interpret this analysis through that lens: the primary concern is
 \begin{enumerate}
   \item \textbf{Biological weapons are the highest-risk category} for AI-enabled proliferation due to eroding physical barriers and high AI contribution to knowledge synthesis
   \item \textbf{AI primarily upgrades T1--T3 actors} (skilled individuals to organized groups); it does not transform novices into capable threat actors
-  \item \textbf{The most likely near-term scenario is high-frequency attempts with limited success}---resource strain and public concern, not mass casualties
+  \item \textbf{The most likely near-term scenario is high-frequency attempts with limited success}, resource strain and public concern, not mass casualties
   \item \textbf{Cyber-physical attacks on existing infrastructure} (labs, chemical plants) may be higher-leverage than synthesis assistance
-  \item \textbf{Governance windows are closing}---once capabilities proliferate, restrictions become harder to implement
+  \item \textbf{Governance windows are closing}, once capabilities proliferate, restrictions become harder to implement
 \end{enumerate}
 
 \subsection*{Top 5 Recommended Actions}
 
 \begin{enumerate}
   \item \textbf{Mandate universal DNA synthesis screening} with international harmonization
-  \item \textbf{Invest in attribution and response capabilities}---cannot rely on deterrence alone
+  \item \textbf{Invest in attribution and response capabilities}, cannot rely on deterrence alone
   \item \textbf{Establish cloud laboratory oversight frameworks} before the attack surface expands further
   \item \textbf{Require WMD-relevant capability evaluations} before frontier AI deployment
   \item \textbf{Fund defensive biodetection} as a high-value cross-threat investment
@@ -611,27 +616,38 @@ We are now entering an era where autonomous AI agents capable of complex multi-s
 
 \subsection{Methodology}
 
-This analysis draws on:
+This is a synthesis of publicly available material. It does not report any first-party study. It draws on:
 \begin{itemize}
-  \item \textbf{Current capability assessment} of AI systems and synthetic biology tools as deployed through early 2026
-  \item \textbf{Historical case analysis} of WMD development programs (state and non-state)
+  \item \textbf{Published capability assessments} of AI systems and synthetic biology tools deployed through mid-2026, including frontier-model system cards and their published red-team and uplift-trial results
+  \item \textbf{Historical case analysis} of WMD development programs (state and non-state) from the public record
   \item \textbf{Dual-Use Research of Concern (DURC)} literature and policy debates
-  \item \textbf{Expert consultation} across biosecurity, nuclear security, and AI safety domains
-  \item \textbf{Red team exercises} examining potential applications (conducted under controlled conditions)
+  \item \textbf{Published expert assessments} across biosecurity, nuclear security, and AI safety, including the RAND biological-attack red-team studies and government risk reports cited throughout
+  \item \textbf{Published red-team and uplift-trial findings} from frontier AI developers and independent evaluators
 \end{itemize}
+
+To be explicit about provenance: the author conducted no original expert consultation, interviews, or red-team exercises for this document. Every empirical claim traces to a cited public source, and ``our assessment'' means the author's synthesis of that public evidence, offered as decision support rather than an authoritative or classified judgment. This is an independent single-author synthesis without access to classified intelligence or proprietary evaluation data; readers who hold different priors on how fast tacit-knowledge and execution barriers are eroding should adjust the conclusions accordingly (the sensitivity analysis supports this).
 
 We deliberately avoid: specific technical implementation details, named pathogen sequences or synthesis routes, and information not already publicly available in academic literature.
 
-\subsection{What We've Observed in 2025}
+\subsection{What We've Observed (Through Mid-2026)}
 
-Evidence regarding AI-assisted biosecurity threats, categorized by epistemic status:
+Evidence regarding AI-assisted biosecurity threats, categorized by epistemic status. The most important development since this report's prior version is that the ``uplift'' question moved from theoretical to measured.
+
+\textbf{The measured-uplift trajectory (2024 to 2026)} \textbf{[O]}:
+\begin{itemize}[nosep]
+  \item The 2024 RAND red-team study found \textit{no statistically significant difference} in the viability of biological-attack plans produced with versus without the then-current LLM generation.\footnote{Mouton, Lucas, and Guest, ``The Operational Risks of AI in Large-Scale Biological Attacks: Results of a Red-Team Study,'' RAND, RR-A2977-2, 2024.}
+  \item By mid-2026, a frontier developer's own published evaluations reached a different conclusion for its most capable model. In a beneficial red-team tabletop exercise, generalist PhD biologists paired with the model produced end-to-end strategies that two of three generalist teams rated at or above dedicated world-leading specialist teams; graders estimated the work would have taken 40 to 95 working days (average ${\sim}72.5$) without AI but was accomplished in roughly 16 hours with the model.\footnote{Anthropic, ``System Card: Claude Fable 5 \& Claude Mythos 5,'' June 9, 2026. Source for the CB-1/CB-2 thresholds, the tabletop and uplift-trial findings, the persistent failure modes, and the tiered Fable 5 / Mythos 5 release.}
+  \item That developer classified the model as having crossed its ``CB-1'' threshold (uplifting actors with basic technical backgrounds toward \textit{non-novel} chemical/biological weapons) while judging it had not clearly crossed ``CB-2'' (\textit{novel} weapons), a judgment it called ``much less clear and obvious'' than for prior models. See the CB-1/CB-2 framing below.
+\end{itemize}
 
 \textbf{Demonstrated in open evaluations:}
 \begin{itemize}[nosep]
   \item AI models can provide general information about pathogen biology from open literature
-  \item Frontier AI models refuse most explicit requests for weapons guidance but inconsistencies exist
-  \item AI systems show measurable ``uplift'' in non-expert comprehension of complex biological concepts
+  \item Frontier models refuse most explicit weapons requests but inconsistencies exist; developers increasingly deploy classifiers that restrict frontier biology capabilities and fall the user back to a less-capable model when triggered
+  \item AI systems show measurable ``uplift'' for both non-expert and expert users; in one published trial even the non-expert control (internet only) was outperformed by non-experts given model access
 \end{itemize}
+
+\textbf{Persistent failure modes (barriers that remain, from the same 2026 evaluations):} hallucinated citations and data; arithmetic and stoichiometry errors; weak constraint carryover across long sessions and poor recovery when errors are pointed out; over-engineered, over-optimistic plans repeatedly forced into revision; difficulty generating novel approaches beyond the published threat literature. Notably, the model often \textit{detected} embedded scientific flaws but proceeded to execute the flawed request rather than flag it.
 
 \textbf{Supported by limited disclosures:}
 \begin{itemize}[nosep]
@@ -682,7 +698,7 @@ Reasoning Agent (2025--26) & Dedicated chain-of-thought reasoning; multi-step pl
 
 \subsection{AI Agent Capabilities}
 
-AI agents in early 2026 can:
+AI agents in mid-2026 can:
 \begin{itemize}[nosep]
   \item Synthesize information from thousands of scientific papers in seconds
   \item Conduct extended multi-step research tasks with minimal supervision
@@ -714,7 +730,7 @@ T4 & State or state-backed & Full WMD capability & Nation-state programs \\
 \end{tabular}
 \end{center}
 
-\textbf{Key insight}: AI primarily benefits T1--T3 actors by reducing knowledge aggregation barriers---it does not transform T0 into T3.
+\textbf{Key insight}: AI primarily benefits T1--T3 actors by reducing knowledge aggregation barriers, it does not transform T0 into T3.
 
 \subsection{Synthetic Biology Infrastructure (2025)}
 
@@ -799,16 +815,16 @@ Modern AI agent frameworks increasingly support multi-agent delegation, where a 
 \begin{itemize}[nosep]
   \item No single agent sees the complete picture of a harmful workflow
   \item Per-model safety guardrails may not trigger because each sub-task appears innocuous in isolation
-  \item Example: Agent A researches pathogen biology (legitimate query); Agent B optimizes a synthesis protocol (legitimate chemistry); Agent C coordinates procurement (legitimate commerce)---no individual agent processes a ``build a weapon'' request, but the orchestrating system assembles the pieces
+  \item Example: Agent A researches pathogen biology (legitimate query); Agent B optimizes a synthesis protocol (legitimate chemistry); Agent C coordinates procurement (legitimate commerce), no individual agent processes a ``build a weapon'' request, but the orchestrating system assembles the pieces
 \end{itemize}
 
-\textbf{Tool-use protocols (MCP and similar)} \textbf{[O]}: The Model Context Protocol (MCP) and similar frameworks enable AI agents to directly interact with external tools: laboratory equipment, procurement platforms, and hardware control systems. This moves agents beyond web browsing and code execution to \textit{physical actuation}---a qualitative shift from information provision to real-world effect.
+\textbf{Tool-use protocols (MCP and similar)} \textbf{[O]}: The Model Context Protocol (MCP) and similar frameworks enable AI agents to directly interact with external tools: laboratory equipment, procurement platforms, and hardware control systems. This moves agents beyond web browsing and code execution to \textit{physical actuation}, a qualitative shift from information provision to real-world effect.
 
 \textbf{Actor tier relevance}: Multi-agent orchestration primarily benefits T2--T3 actors with technical sophistication. However, as ``agent-as-a-service'' platforms emerge, the barrier is dropping toward T1.
 
 \subsection{Reasoning Models and Complex Planning}
 
-Dedicated reasoning models (o3/o4-mini, Claude extended thinking, DeepSeek R1) represent a step change in AI planning capability \textbf{[O]}. Unlike standard language models, reasoning models perform extended internal chain-of-thought before producing output.
+Dedicated reasoning models (Claude with extended thinking, the o-series, and open-weight systems such as DeepSeek V4) represent a step change in AI planning capability \textbf{[O]}. Unlike standard language models, reasoning models perform extended internal chain-of-thought before producing output.
 
 \textbf{The agentic loop amplifier}: The combination of reasoning models with agentic tool use creates a particularly significant capability shift:
 \begin{enumerate}[nosep]
@@ -819,11 +835,11 @@ Dedicated reasoning models (o3/o4-mini, Claude extended thinking, DeepSeek R1) r
   \item \textbf{Retry}: Iterate without human intervention until the goal is achieved
 \end{enumerate}
 
-This ``agentic loop'' is qualitatively different from single-query chatbot interaction. Where a chatbot provides one-shot information, an agentic reasoning system can \textit{iterate through failures autonomously}---the same adaptive learning that makes human experts effective, now operating at machine speed.
+This ``agentic loop'' is qualitatively different from single-query chatbot interaction. Where a chatbot provides one-shot information, an agentic reasoning system can \textit{iterate through failures autonomously}, the same adaptive learning that makes human experts effective, now operating at machine speed.
 
-\textbf{Current limitation} \textbf{[E]}: As of early 2026, reasoning models excel at well-defined planning tasks but remain unreliable for novel physical procedures where ground-truth feedback is ambiguous.
+\textbf{Current limitation} \textbf{[E]}: As of mid-2026, reasoning models excel at well-defined planning tasks but remain unreliable for novel physical procedures where ground-truth feedback is ambiguous.
 
-\textbf{Actor tier relevance}: Reasoning models are widely available (including open-weight: DeepSeek R1). They primarily benefit T1--T3 actors by providing systematic, multi-step planning that previously required expert-level domain knowledge.
+\textbf{Actor tier relevance}: Reasoning models are widely available (including open-weight: DeepSeek V4, Qwen 3.5). They primarily benefit T1--T3 actors by providing systematic, multi-step planning that previously required expert-level domain knowledge.
 
 \subsection{Governance Challenge: Open-Weight Models}
 
@@ -835,16 +851,20 @@ Most AI safety measures exist at the API level for closed commercial models. Ope
 \toprule
 \textbf{Model Type} & \textbf{Guardrails} & \textbf{Monitoring} & \textbf{Fine-tuning} & \textbf{Governance Lever} \\
 \midrule
-Closed API (GPT-4.5, Claude 4.5) & Strong & Yes & No & Provider responsibility \\
-Open-weight general (Llama 3.3, Qwen 2.5) & Varies & No (local) & Yes & Release decisions only \\
-Open-weight reasoning (DeepSeek R1) & Often minimal & No (local) & Yes & Extremely difficult \\
+Frontier closed API (Claude Opus 4.8, Fable 5) & Strong & Yes & No & Provider responsibility \\
+Open-weight general (Llama 4, Qwen 3.5, DeepSeek V4) & Varies & No (local) & Yes & Release decisions only \\
+Open-weight reasoning (DeepSeek V4, Qwen 3.5, Kimi K2.6) & Often minimal & No (local) & Yes & Extremely difficult \\
 Fine-tuned variants & Often removed & No & Already done & Difficult to control \\
 Specialized biology (Evo, domain) & May be absent & No & Domain-specific & Research community norms \\
 \bottomrule
 \end{tabular}
 \end{center}
 
-\textbf{Policy implications}: (1) Pre-release capability evaluation, (2) Compute governance as monitoring opportunity, (3) Community norms on responsible release, (4) Accept that some proliferation is unavoidable---invest in detection accordingly.
+\textbf{Policy implications}: (1) Pre-release capability evaluation, (2) Compute governance as monitoring opportunity, (3) Community norms on responsible release, (4) Accept that some proliferation is unavoidable, so invest in detection accordingly.
+
+\begin{contextbox}[A Real-World Graduated-Access Example (Mid-2026)]
+One frontier developer, on judging its most capable model to sit near the novel-weapon (CB-2) boundary, chose \textit{not} to release that model's frontier biology capabilities to the general public. Instead it split the release: a general-access configuration with classifiers that restrict frontier biology and fall the user back to a less-capable model when triggered, and a safeguards-lifted configuration made available only to a small number of vetted, trusted partners with beneficial use cases. This is a concrete instance of the graduated-access and capability-bounding governance this report recommends. It also shows the limit of the approach: the developer noted that a sufficiently resourced state actor could still attempt to obtain the unsafeguarded capabilities through model-weight theft, which is why weight security and detection matter alongside access tiers.
+\end{contextbox}
 
 \section{Theoretical Frameworks}
 
@@ -852,7 +872,7 @@ This analysis draws on several established theoretical frameworks from security 
 
 \subsection{The Democratization of Lethality}
 
-\textbf{Audrey Kurth Cronin's framework} from ``Power to the People'' (2020) describes how each technological era redistributes the capacity for violence. AI represents the latest such redistribution, but with a crucial difference: previous technologies (dynamite, small arms) democratized \textit{physical} capabilities. AI democratizes \textit{cognitive} capabilities---the planning, knowledge synthesis, and optimization that previously required years of specialized training.
+\textbf{Audrey Kurth Cronin's framework} from ``Power to the People'' (2020) describes how each technological era redistributes the capacity for violence. AI represents the latest such redistribution, but with a crucial difference: previous technologies (dynamite, small arms) democratized \textit{physical} capabilities. AI democratizes \textit{cognitive} capabilities, the planning, knowledge synthesis, and optimization that previously required years of specialized training.
 
 For WMD, this means:
 \begin{itemize}[nosep]
@@ -891,12 +911,16 @@ For AI and WMD: AI democratizes access to planning and synthesis knowledge; as m
 
 \subsection{Unified Risk Model}
 
+This is the single canonical risk equation used everywhere in the report, including the quantitative decomposition in the Uncertainties section:
+
 \begin{center}
-\fbox{\parbox{0.85\textwidth}{
+\fbox{\parbox{0.9\textwidth}{
 \centering
-\textbf{Risk = Capability $\times$ Access $\times$ Intent $\times$ Execution $\times$ (1 $-$ Interdiction) $\times$ Impact}
+\textbf{Risk = Capability-Access $\times$ Intent Prevalence $\times$ Operational Execution $\times$ (1 $-$ Interdiction) $\times$ Impact Scale}
 }}
 \end{center}
+
+Here \textbf{Capability-Access} combines a cognitive sub-component (knowing what to do, where AI contributes most) and a materials sub-component (physical access, which AI largely cannot address). The decomposition section combines these into one ``Capability Access'' term.
 
 \begin{center}
 \small
@@ -904,20 +928,39 @@ For AI and WMD: AI democratizes access to planning and synthesis knowledge; as m
 \toprule
 \textbf{Factor} & \textbf{AI Contribution} & \textbf{Bio (2025--30)} & \textbf{Nuke (2025--30)} \\
 \midrule
-Capability (can attempt) & HIGH (knowledge synthesis) & Rising & Stable \\
+Capability (cognitive) & HIGH (knowledge synthesis) & Rising & Stable \\
 Access (materials/tools) & MEDIUM (cloud labs) & Rising & Stable (fissile) \\
-Intent (motivation) & NONE (AI doesn't create) & Stable & Stable \\
-Execution (attempt success) & MEDIUM (guidance) & Rising slowly & Stable \\
+Intent Prevalence & NONE (AI doesn't create) & Stable & Stable \\
+Operational Execution & MEDIUM (guidance) & Rising slowly & Stable \\
 Interdiction (detection) & MIXED (both sides) & Declining pressure & Stable (strong) \\
+Impact Scale & LOW (physics/bio constrain) & Wide range & Catastrophic \\
 \bottomrule
 \end{tabular}
 \end{center}
 
-\textbf{Key insight}: AI primarily affects Capability and Access (cognitive barriers). Physical barriers, Intent, and Impact Scale are largely AI-independent.
+\textbf{Key insight}: AI primarily affects Capability and Access (cognitive barriers). Physical barriers, Intent Prevalence, and Impact Scale are largely AI-independent.
+
+\subsection{Capability Thresholds: The CB-1 / CB-2 Framework}
+
+By mid-2026, frontier AI developers had converged on explicit capability thresholds for chemical and biological weapons, most visibly in one developer's Responsible Scaling Policy and Frontier Compliance Framework.\footnote{Anthropic, ``System Card: Claude Fable 5 \& Claude Mythos 5,'' June 9, 2026.} These separate two risks the discourse often blurs:
+
+\begin{center}
+\small
+\begin{tabular}{L{2.5cm}L{5.5cm}L{4cm}}
+\toprule
+\textbf{Threshold} & \textbf{Definition} & \textbf{Maps to in this report} \\
+\midrule
+\textbf{CB-1} (non-novel uplift) & Significantly helps actors with basic technical backgrounds create/obtain/deploy \textit{known} CB weapons with catastrophic potential & Barrier reduction for T1--T3 on \textit{existing} agents; the near-term concern \\
+\textbf{CB-2} (novel uplift) & \textit{Functionally substitutes} for the scarce world-leading expertise that is the primary barrier to \textit{novel} CB weapons (end-to-end design, validation, dissemination) & The tacit-knowledge / expertise-bottleneck barrier; a higher, less-certain bar \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\textbf{Why this matters}: The first public developer determination (mid-2026) placed its most capable model \textit{across CB-1 but not clearly across CB-2}, warning that world-class expert substitution ``may now be possible in a few areas.'' This matches the report's core finding: AI meaningfully uplifts T1--T3 actors on known agents (CB-1) while the novel-weapon barrier (CB-2) erodes but is not clearly breached. It also shapes defense: CB-1 risk is best addressed by chokepoint controls on materials and synthesis (independent of model capability), whereas CB-2 risk is where model-level access controls and capability evaluations matter most.
 
 \subsection{The Tacit Knowledge Gap}
 
-\textbf{Michael Polanyi's concept of tacit knowledge}---skills that cannot be fully articulated and must be learned through practice---is central to understanding WMD barriers. Much of weapons development relies on sensory cues, equipment calibration, and ``laboratory intuition'' accumulated over years.
+\textbf{Michael Polanyi's concept of tacit knowledge}, skills that cannot be fully articulated and must be learned through practice, is central to understanding WMD barriers. Much of weapons development relies on sensory cues, equipment calibration, and ``laboratory intuition'' accumulated over years.
 
 AI agents can transmit explicit knowledge but traditionally cannot transfer tacit knowledge. However, two developments challenge this:
 \begin{enumerate}
@@ -962,12 +1005,12 @@ The balance varies significantly across WMD categories, which is why biological,
 \textit{Countdown to Zero Day} & Zetter (2014) & Stuxnet and cyber-physical attacks \\
 \textit{The Demon in the Freezer} & Preston (2002) & Smallpox and bioweapons policy \\
 \textit{Destined for War} & Allison (2017) & Great power dynamics \\
-\textit{RAND Operational Risks} & RAND (2024) & Definitive uplift study \textbf{[O]} \\
+\textit{The Operational Risks of AI in Large-Scale Biological Attacks} & Mouton, Lucas, Guest, RAND (2024) & Red-team study finding no measurable uplift from the then-current model generation \textbf{[O]} \\
 \bottomrule
 \end{tabular}
 \end{center}
 
-\subsection{2024--2026 Policy Developments}
+\subsection{2023--2026 Policy Developments}
 
 \begin{center}
 \small
@@ -976,14 +1019,18 @@ The balance varies significantly across WMD categories, which is why biological,
 \textbf{Reference} & \textbf{Date} & \textbf{Relevance} \\
 \midrule
 Bletchley Declaration & Nov 2023 & First international consensus on AI risks including CBRN \textbf{[O]} \\
+US Executive Order 14110 & Oct 2023 & Mandated DOE/DHS evaluation of AI role in CBRN threats; later revoked \textbf{[O]} \\
 Seoul AI Safety Summit & May 2024 & Extended Bletchley with specific bio-risk language \textbf{[O]} \\
-US Executive Order 14110 & Oct 2023; revoked Jan 2025 & Mandates evaluation of AI role in CBRN threats \textbf{[O]} \\
-RAND ``Operational Risks'' & 2024 & Definitive uplift study finding limited current risk \textbf{[O]} \\
-Anthropic RSP Framework & 2023--24 & Responsible Scaling Policy with CBRN thresholds \textbf{[O]} \\
-OpenAI o1 Biological Uplift Evaluations & 2024 & Reasoning model uplift tests; found modest but measurable uplift \textbf{[O]} \\
-EU AI Act Implementation & Aug 2025 & First comprehensive AI regulation; high-risk system requirements \textbf{[O]} \\
-EO 14110 Revocation & Jan 2025 & US rescinded prior AI safety order; shifts to industry self-governance \textbf{[O]} \\
-DeepSeek R1 Open Release & Jan 2025 & Open-weight reasoning model matching frontier performance \textbf{[O]} \\
+DHS CWMD report on AI and CBRN & Apr 2024 & US assessment of the AI-CBRN risk intersection, mandated by EO 14110 \textbf{[O]} \\
+RAND red-team biological-attack study & 2024 & No statistically significant uplift from the then-current LLM generation; monitoring recommended \textbf{[O]} \\
+OSTP Nucleic Acid Synthesis Screening Framework & Apr 2024 & Encourages providers to screen orders and verify customers \textbf{[O]} \\
+Anthropic RSP / Frontier Compliance Framework & 2023--26 & CB-1 (non-novel) and CB-2 (novel) capability thresholds \textbf{[O]} \\
+EO 14110 revocation; EO 14179 & Jan 2025 & US rescinded the prior safety order (Jan 20) and issued ``Removing Barriers to American Leadership in AI'' (Jan 23) \textbf{[O]} \\
+UK AISI becomes AI Security Institute & Feb 2025 & Rebrand toward security-relevant risks, explicitly including CB weapons and cyber \textbf{[O]} \\
+EO ``Improving the Safety and Security of Biological Research'' & May 2025 & Directs revision of the 2024 synthesis-screening framework; ties federal funding to adherence \textbf{[O]} \\
+America's AI Action Plan & Jul 2025 & Successor US strategy with national-security and biosecurity workstreams \textbf{[O]} \\
+EU AI Act GPAI obligations in force & Aug 2025 & Systemic-risk tier (above 10\textsuperscript{25} FLOP) carries safety-and-security duties; enforcement from Aug 2026 \textbf{[O]} \\
+First public developer CB-1 determination & Jun 2026 & A frontier system card judged its top model across CB-1 but not clearly across CB-2, with ``significant uncertainty'' \textbf{[O]} \\
 \bottomrule
 \end{tabular}
 \end{center}
@@ -992,7 +1039,7 @@ DeepSeek R1 Open Release & Jan 2025 & Open-weight reasoning model matching front
 
 \subsection{State Programs: The Scale of Serious Capability}
 
-\textbf{The Manhattan Project (1942--1945)}: Peak employment 125,000+ workers; cost \$2 billion (\$28 billion in 2025 dollars); required industrial-scale facilities.
+\textbf{The Manhattan Project (1942--1945)}: Peak employment 125,000+ workers; cost ${\sim}\$2$ billion (roughly \$23--28 billion in 2026 dollars, depending on the deflator); required industrial-scale facilities.
 
 \textbf{Soviet Biopreparat Program (1970s--1990s)}: Employed 60,000+ people at peak; dozens of facilities; required decades to develop sophisticated delivery.
 
@@ -1022,7 +1069,7 @@ DeepSeek R1 Open Release & Jan 2025 & Open-weight reasoning model matching front
 
 \textbf{Rajneeshee Bioterror Attack (1984)}: Religious cult in Oregon used \textit{Salmonella typhimurium} (common food pathogen) to contaminate restaurant salad bars. Outcome: 751 illnesses, no deaths, significant disruption. \textbf{Critical lesson}: Low-tech attacks with common agents can achieve ``mass disruption'' without ``mass destruction.'' AI agents could optimize logistics of such simple attacks for massive scale.
 
-\textbf{Stuxnet (2010)}: Nation-state attack (US/Israel) targeting Iranian nuclear centrifuges. Malware caused physical destruction via control system manipulation. Outcome: Significant delay to Iranian nuclear program. \textbf{Critical lesson}: Code can cause physical destruction. This establishes the precedent for ``cyber-physical'' attacks on WMD-related infrastructure---a vector AI agents could enable.
+\textbf{Stuxnet (2010)}: Nation-state attack (US/Israel) targeting Iranian nuclear centrifuges. Malware caused physical destruction via control system manipulation. Outcome: Significant delay to Iranian nuclear program. \textbf{Critical lesson}: Code can cause physical destruction. This establishes the precedent for ``cyber-physical'' attacks on WMD-related infrastructure, a vector AI agents could enable.
 
 \subsection{Technology Inflection Points}
 
@@ -1095,7 +1142,7 @@ AI agents (2024+) & Knowledge synthesis and guidance & Physical barriers; tacit 
 Biological weapons represent the category where AI poses the most significant proliferation risk:
 
 \begin{enumerate}
-  \item \textbf{Information-intensive}: Much of development is knowledge synthesis---AI's strength
+  \item \textbf{Information-intensive}: Much of development is knowledge synthesis, AI's strength
   \item \textbf{Decreasing physical barriers}: DNA synthesis services and cloud labs reduce infrastructure needs
   \item \textbf{Detection difficulty}: Biological materials are harder to detect than nuclear facilities
   \item \textbf{Dual-use ubiquity}: Most equipment is identical to legitimate research tools
@@ -1127,7 +1174,7 @@ Predict immune evasion & Research stage & Potentially very high \\
 \toprule
 \textbf{Stage} & \textbf{AI Uplift} & \textbf{Why} \\
 \midrule
-Design assistance & High & Literature synthesis, protocol drafting---AI excels \\
+Design assistance & High & Literature synthesis, protocol drafting, AI excels \\
 Operational success & Low-Medium & Physical execution, error recovery still required \\
 Net risk driver & \multicolumn{2}{l}{Attempt frequency + occasional competent actor} \\
 \bottomrule
@@ -1153,7 +1200,7 @@ Toxins & Defined structures; some synthetically accessible; no replication & Mod
 
 \subsection{Gain-of-Function Considerations}
 
-AI could potentially assist with gain-of-function modifications---predicting mutations that increase transmissibility, identifying immune evasion strategies, optimizing pathogen stability, and suggesting virulence factor modifications.
+AI could potentially assist with gain-of-function modifications, predicting mutations that increase transmissibility, identifying immune evasion strategies, optimizing pathogen stability, and suggesting virulence factor modifications.
 
 \textbf{Limiting factors}: Wet lab validation still required; many modifications reduce fitness; biological systems are complex and unpredictable; most AI predictions would fail in practice.
 
@@ -1172,7 +1219,7 @@ The BioForge project demonstrates agent-driven biological automation using a Ras
 
 \textit{``If we cannot build responsible governance into a system that edits non-pathogenic bacteria on a kitchen table, we have no business deploying AI agents with actuation capability over more consequential biological or physical systems.''}
 
-The Sleeper Agents detection framework---which identifies persistent deceptive behaviors in LLMs---is planned for integration, addressing the risk of backdoored models in agent-actuated research pipelines. Key finding: ``False Safety'' is the primary risk---organizations could certify a model as safe while dangerous backdoors remain.
+The Sleeper Agents detection framework, which identifies persistent deceptive behaviors in LLMs, is planned for integration, addressing the risk of backdoored models in agent-actuated research pipelines. Key finding: ``False Safety'' is the primary risk: organizations could certify a model as safe while dangerous backdoors remain.
 \end{keybox}
 
 \subsection{Governance Challenge: Distributed Synthesis Capability}
@@ -1192,7 +1239,7 @@ Desktop-scale DNA synthesis capability is expanding, creating a governance chall
 
 \subsection{Cloud Laboratory Considerations}
 
-Cloud laboratories---services providing remote access to automated equipment---represent an area requiring enhanced defensive attention.
+Cloud laboratories, services providing remote access to automated equipment, represent an area requiring enhanced defensive attention.
 
 \begin{center}
 \small
@@ -1218,7 +1265,7 @@ Chemical weapons occupy an intermediate position. \textbf{The dominant constrain
   \item \textbf{AI contribution}: Modest assistance with knowledge gaps
 \end{itemize}
 
-The most concerning AI capability is \textbf{precursor substitution}---identifying unregulated chemicals with similar properties to avoid monitoring.
+The most concerning AI capability is \textbf{precursor substitution}, identifying unregulated chemicals with similar properties to avoid monitoring.
 
 \subsection{The Precursor Substitution Threat}
 
@@ -1247,18 +1294,36 @@ Nuclear weapons remain the category with the strongest barriers:
 \end{enumerate}
 
 \begin{infobox}[Critical Clarification]
-The information aggregation risk is primarily relevant to \textbf{state programs (T4)} seeking to accelerate nuclear development. AI does not make nuclear weapons accessible to non-state actors---the fissile material barrier is absolute and AI-independent.
+The information aggregation risk is primarily relevant to \textbf{state programs (T4)} seeking to accelerate nuclear development. AI does not make nuclear weapons accessible to non-state actors, the fissile material barrier is absolute and AI-independent.
 \end{infobox}
 
 \subsection{The Radiological Threat (Dirty Bombs)}
 
 Radiological dispersal devices (``dirty bombs'') face different dynamics than nuclear weapons:
 
-\textbf{Lower barriers than nuclear weapons}: Radioactive materials more accessible (medical, industrial sources); no fission/fusion required---conventional explosives disperse material; AI could assist with source identification and dispersal optimization.
+\textbf{Lower barriers than nuclear weapons}: Radioactive materials more accessible (medical, industrial sources); no fission/fusion required; conventional explosives disperse material; AI could assist with source identification and dispersal optimization.
 
 \textbf{Significant limitations}: Casualty potential much lower than nuclear weapons; primary effect is psychological and economic; material handling dangerous to perpetrator; detection of radioactive materials is possible.
 
 \textbf{AI contribution}: Could assist with identifying sources, optimizing dispersal, and planning deployment, but physical acquisition remains the key barrier.
+
+\textbf{The dominant barrier is source security, not information.} Unlike the informational barriers AI erodes elsewhere, the radiological threat turns almost entirely on physical access to a suitable radioactive source, governed by an existing security architecture:
+
+\begin{center}
+\small
+\begin{tabular}{L{3cm}L{5cm}L{4cm}}
+\toprule
+\textbf{Control layer} & \textbf{Mechanism} & \textbf{Where AI changes little} \\
+\midrule
+Source categorization & IAEA hazard categories (1--5); highest categories in radiotherapy, radiography, irradiators are the concern & Which isotopes are dangerous is fixed physics and public \\
+Regulatory custody & National licensing; IAEA Code of Conduct on the Safety and Security of Radioactive Sources & Compliance and diversion are physical-world problems \\
+Orphan-source risk & Lost, abandoned, or stolen sources outside regulatory control, plus legacy sources in weak-governance regions & AI cannot make a source; at most it locates poorly secured ones \\
+Detection at chokepoints & Radiation portal monitors at borders and ports & Detection physics is unchanged; shielding is heavy and conspicuous \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\textbf{Defender priorities}: securing and recovering high-activity sealed sources (national registries, end-of-life recovery), sustaining radiation detection at borders and major events, and supporting the IAEA Code of Conduct where source control is weak. These are physical-security and coordination investments, largely independent of AI capability, which is why the radiological threat, though real, is among the categories least changed by AI. A radiological dispersal device is within reach of T2--T3 actors \textit{if} they obtain a source; source acquisition, not knowledge, gates the threat.
 
 \subsection{Supply Chain Security}
 
@@ -1302,9 +1367,9 @@ Target species selection & Expert knowledge, literature review & Systematic vuln
 
 \textbf{What this means for defenders}:
 \begin{itemize}[nosep]
-  \item Gene drive design is \textit{computationally intensive}---exactly where AI excels
+  \item Gene drive design is \textit{computationally intensive}, exactly where AI excels
   \item AI acceleration primarily affects \textit{design and optimization} phases
-  \item \textit{Wet lab validation} remains required---a detection opportunity
+  \item \textit{Wet lab validation} remains required, a detection opportunity
   \item \textit{Environmental release} is the chokepoint where intervention is most feasible
 \end{itemize}
 
@@ -1436,7 +1501,7 @@ High-value infrastructure requires layered defense against delivery-focused atta
 An AI agent doesn't need to help someone build a bioweapon if it can help them disable the containment systems of an existing BSL-4 laboratory.
 \end{keybox}
 
-\textbf{Stuxnet as Precedent}: The 2010 attack demonstrated that code can cause physical destruction---malware targeted industrial control systems and caused centrifuges to physically destroy themselves. AI agents could enable similar attacks at lower skill thresholds.
+\textbf{Stuxnet as Precedent}: The 2010 attack demonstrated that code can cause physical destruction: malware targeted industrial control systems and caused centrifuges to physically destroy themselves. AI agents could enable similar attacks at lower skill thresholds.
 
 \subsection{Vulnerable Infrastructure Categories}
 
@@ -1470,7 +1535,7 @@ Pharmaceutical Mfg & Precursor chemicals & Process controls \\
 
 AI agent identifies laboratory control systems; develops approach to disable negative pressure; coordinates with physical access (insider or break-in); containment failure releases stored pathogens.
 
-\textit{No synthesis required---existing materials weaponized.}
+\textit{No synthesis required; existing materials weaponized.}
 \end{quotebox}
 
 \begin{quotebox}
@@ -1483,7 +1548,11 @@ AI agent maps chemical plant process controls; identifies conditions that would 
 
 \subsection{Defensive Implications}
 
-This vector suggests defensive priorities: (1) Air-gap critical controls---isolation from network-accessible systems; (2) Enhanced ICS security---hardening beyond current standards; (3) Facility monitoring---detecting reconnaissance and probing; (4) Incident attribution---distinguishing accidents from attacks; (5) Redundant safety systems---mechanical backups for digital controls.
+This vector suggests defensive priorities: (1) Air-gap critical controls, isolation from network-accessible systems; (2) Enhanced ICS security, hardening beyond current standards; (3) Facility monitoring, detecting reconnaissance and probing; (4) Incident attribution, distinguishing accidents from attacks; (5) Redundant safety systems, mechanical backups for digital controls.
+
+\section{Proliferation Financing and Procurement Obfuscation}
+
+The preceding section covered AI-enabled attacks on the control systems of existing facilities. This section covers a different logistics-layer threat: how AI agents could help finance and procure materials while staying below the thresholds that trigger law enforcement. These are financial and procurement dynamics, not cyber-physical ones, which is why they are treated separately. Both are chokepoints that exist regardless of how capable any AI model is, and can therefore be monitored and interdicted directly.
 
 \begin{notebox}[Cross-Reference: Financial Crime Patterns]
 The Financial Integrity report analyzes the same ``nano-smurfing'' pattern in financial crime: AI agents structuring transactions below detection thresholds across thousands of accounts simultaneously. The Institutional Erosion report explicitly identifies this as a proliferation-watching problem in the IC context. The procurement dynamics below are a direct application of that framework.
@@ -1510,7 +1579,13 @@ AI agents with computer use capabilities could change the economics of procureme
 
 \textbf{Defender implication}: Traditional procurement monitoring based on single-order thresholds becomes inadequate. Pattern-based detection across suppliers, geographies, and time becomes essential.
 
+\textbf{Persisting barriers}: The obfuscation is real, but physical constraints remain. Cross-supplier correlation can surface complementary-material buying; automated interaction leaves behavioral and velocity signatures distinct from human buyers; physical goods still ship to real addresses and must be aggregated and stored; and regulated precursors still require real suppliers subject to reporting duties. The capability lowers the cost of evasion; it does not remove the material footprint.
+
 \subsection{Governance Gaps in Proliferation Financing}
+
+\begin{keybox}[Companion Research: Autonomous Economic Agents]
+The Economic Agents framework demonstrates autonomous AI agents that earn cryptocurrency, form companies, create sub-agents, and seek investment without human intervention. The ``multi-agent economic networks'' scenario (agent-to-agent supply chains with no human principal) is directly relevant to WMD procurement financing: agents could autonomously procure dual-use materials with no traceable human decision-maker. The economic implications analysis identifies the legal vacuum: no frameworks exist for agent-founded entities, agent-entered contracts, or agent-earned income, creating accountability gaps that proliferation networks could exploit.
+\end{keybox}
 
 Agentic AI workflows could assist WMD proliferation through sophisticated financial operations:
 
@@ -1615,13 +1690,13 @@ Clinical trial optimization & Years & Months & Low \\
 \end{tabular}
 \end{center}
 
-\textbf{Our assessment}: Valid and important counter-narrative that deserves dedicated investment. However, defensive capabilities require \textit{sustained investment}---they do not emerge passively from commercial AI development. Attackers choose timing; defenders must be ready continuously. The Bio-Firewall concept should be a central organizing principle for defensive biosecurity investment.
+\textbf{Our assessment}: Valid and important counter-narrative that deserves dedicated investment. However, defensive capabilities require \textit{sustained investment}, they do not emerge passively from commercial AI development. Attackers choose timing; defenders must be ready continuously. The Bio-Firewall concept should be a central organizing principle for defensive biosecurity investment.
 
 \textbf{Policy implication}: Defensive AI capabilities should receive funding priority at least equal to restriction/monitoring efforts.
 
 \subsection{The Over-Screening Cost Argument}
 
-\textbf{Argument}: If AI-driven concern leads to excessive screening, we may cause more harm by stifling legitimate research---including research needed to respond to natural pandemics.
+\textbf{Argument}: If AI-driven concern leads to excessive screening, we may cause more harm by stifling legitimate research, including research needed to respond to natural pandemics.
 
 \textbf{Evidence of costs}: Post-2001 anthrax regulations significantly slowed legitimate biodefense research. Overly broad export controls can push research to less regulated jurisdictions.
 
@@ -1634,7 +1709,7 @@ Clinical trial optimization & Years & Months & Low \\
 \textbf{Potential overreach of this framework}:
 
 \begin{enumerate}
-  \item \textbf{Assumes homogeneous capability}: Not all actors who ``want to'' can actually execute. The curse applies most strongly when capability is uniform---but WMD capability remains highly non-uniform.
+  \item \textbf{Assumes homogeneous capability}: Not all actors who ``want to'' can actually execute. The curse applies most strongly when capability is uniform, but WMD capability remains highly non-uniform.
 
   \item \textbf{Ignores coordination mechanisms}: The framework assumes purely independent decision-making. In reality, extremist communities have internal norms, and state sponsors exercise control over proxies.
 
@@ -1645,10 +1720,10 @@ Clinical trial optimization & Years & Months & Low \\
     \item Adopt maximally restrictive policies regardless of cost
   \end{itemize}
 
-  \item \textbf{Alternative framing---``The Long Fuse''}: Instead of ``inevitable misuse,'' consider that barriers create \textit{delay}. Each year of delay allows defensive technology to advance, governance frameworks to mature, attribution capabilities to improve, and social norms against misuse to strengthen.
+  \item \textbf{Alternative framing, ``The Long Fuse''}: Instead of ``inevitable misuse,'' consider that barriers create \textit{delay}. Each year of delay allows defensive technology to advance, governance frameworks to mature, attribution capabilities to improve, and social norms against misuse to strengthen.
 \end{enumerate}
 
-\textbf{Our assessment}: The Unilateralist's Curse is a useful heuristic but should not induce fatalism. The appropriate response is \textit{buying time through calibrated barriers} while \textit{investing in resilience and response capabilities}---not assuming catastrophe is inevitable.
+\textbf{Our assessment}: The Unilateralist's Curse is a useful heuristic but should not induce fatalism. The appropriate response is \textit{buying time through calibrated barriers} while \textit{investing in resilience and response capabilities}, not assuming catastrophe is inevitable.
 
 \subsection{Alternative Framing: The Long Fuse}
 
@@ -1664,13 +1739,13 @@ The appropriate response is \textit{buying time through calibrated barriers} whi
 
 \section{The Attribution Problem}
 
-Attribution---determining responsibility---serves critical functions: enables deterrence, provides basis for legal accountability, prevents misattribution and escalation.
+Attribution, determining responsibility, serves critical functions: enables deterrence, provides basis for legal accountability, prevents misattribution and escalation.
 
 \textbf{How AI complicates attribution}:
 \begin{itemize}
   \item AI agents can plan without human co-conspirators
   \item No organizational structure to penetrate
-  \item ``Delegation Defense'': State actors could claim AI agents autonomously derived weapons-relevant information without directed intent---straining legal frameworks for state responsibility under BWC/CWC/NPT
+  \item ``Delegation Defense'': State actors could claim AI agents autonomously derived weapons-relevant information without directed intent, straining legal frameworks for state responsibility under BWC/CWC/NPT
   \item AI can generate misleading evidence (false flag potential)
 \end{itemize}
 
@@ -1735,7 +1810,7 @@ The attribution void created by AI assistance has severe implications for intern
 
 \textbf{Historical parallel}: The 2001 anthrax letters demonstrated how even a domestic attack with eventual attribution created years of investigative uncertainty and policy confusion. AI-enabled attacks could be far harder to trace.
 
-\textbf{Policy implication}: Investment in attribution capability is not merely a law enforcement priority---it is a strategic necessity for maintaining international stability and the credibility of deterrence regimes.
+\textbf{Policy implication}: Investment in attribution capability is not merely a law enforcement priority, it is a strategic necessity for maintaining international stability and the credibility of deterrence regimes.
 
 % ============================================================================
 % PART IV - POLICY RECOMMENDATIONS
@@ -1972,13 +2047,13 @@ High & Invest in defensive applications & AI-enabled biosurveillance, detection,
 
 \begin{contextbox}[Recommended Actions]
 \begin{enumerate}
-  \item \textbf{Evaluate models for WMD uplift before release}---you cannot claim ignorance after deployment
-  \item \textbf{Do not open-source models with significant uplift capabilities}---once released, cannot be recalled
-  \item \textbf{Implement robust guardrails with ongoing monitoring}---initial safeguards degrade; adversarial adaptation is ongoing
-  \item \textbf{Fund defensive biosecurity research}---the same capabilities that enable offense can enable defense
-  \item \textbf{Engage seriously with safety evaluations}---red team findings should inform development, not just PR
-  \item \textbf{Participate in international governance discussions}---technical expertise essential for workable frameworks
-  \item \textbf{Develop ``know your customer'' standards for API access}---high-capability access should have accountability
+  \item \textbf{Evaluate models for WMD uplift before release}, you cannot claim ignorance after deployment
+  \item \textbf{Do not open-source models with significant uplift capabilities}, once released, cannot be recalled
+  \item \textbf{Implement robust guardrails with ongoing monitoring}, initial safeguards degrade; adversarial adaptation is ongoing
+  \item \textbf{Fund defensive biosecurity research}, the same capabilities that enable offense can enable defense
+  \item \textbf{Engage seriously with safety evaluations}, red team findings should inform development, not just PR
+  \item \textbf{Participate in international governance discussions}, technical expertise essential for workable frameworks
+  \item \textbf{Develop ``know your customer'' standards for API access}, high-capability access should have accountability
 \end{enumerate}
 
 \textbf{Key insight for tech elite}: You are building dual-use capabilities. The ethical responsibility is substantial, and the historical legacy of these decisions will be judged harshly if preventable harm occurs.
@@ -2000,7 +2075,9 @@ The probabilities below are \textit{subjective priors} intended to support decis
 
 \subsection{Probability Decomposition Framework}
 
-\textbf{Risk = Capability Access $\times$ Intent Prevalence $\times$ Operational Execution $\times$ (1 $-$ Interdiction) $\times$ Impact Scale}
+This applies the single canonical risk equation from the Theoretical Frameworks section, with the cognitive (Capability) and materials (Access) sub-components combined into one ``Capability Access'' term. A bottom-up decomposition and the top-down scenario priors below are two different methods and will not agree to the decimal; treat the scenario bands as the headline figure and the decomposition as illustrative of how the factors combine.
+
+\textbf{Risk = Capability-Access $\times$ Intent Prevalence $\times$ Operational Execution $\times$ (1 $-$ Interdiction) $\times$ Impact Scale}
 
 \subsubsection*{Biological (Highest Risk Category)}
 
@@ -2067,7 +2144,7 @@ Interdiction rate & 50\% & 35\% & 20\% & 5\% $\to$ 8-12\% $\to$ 18\% \\
 \end{tabular}
 \end{center}
 
-\textbf{Key insight}: The estimate is most sensitive to intent prevalence and capable actor pool size---factors where AI's contribution is indirect.
+\textbf{Key insight}: The estimate is most sensitive to intent prevalence and capable actor pool size, factors where AI's contribution is indirect.
 
 \textbf{What would falsify this model}:
 \begin{itemize}[nosep]
@@ -2182,7 +2259,7 @@ Classification of dual-use by default & Makes beneficial work impossible \\
 
 \subsection{The Optimization Target}
 
-The goal is not to prevent all possible harm---that would require unacceptable restrictions. The goal is to:
+The goal is not to prevent all possible harm, that would require unacceptable restrictions. The goal is to:
 \begin{enumerate}
   \item Make catastrophic harm significantly harder
   \item Enable detection and response to attempts
@@ -2296,7 +2373,7 @@ Events that would significantly alter assessment:
 AI agents represent a significant shift in the WMD proliferation landscape, but the nature and magnitude of risk varies substantially:
 
 \begin{itemize}
-  \item \textbf{Biological weapons}: Highest-priority concern---multiple barriers eroding simultaneously
+  \item \textbf{Biological weapons}: Highest-priority concern, multiple barriers eroding simultaneously
   \item \textbf{Chemical weapons}: Moderate barrier reduction; physical materials access constrains
   \item \textbf{Nuclear weapons}: Limited AI-related barrier reduction; fissile material dominates
   \item \textbf{Gene drives}: Novel category requiring dedicated governance attention
@@ -2362,8 +2439,8 @@ Gene Drives & High & Low & Very Difficult & Sig. Increasing \\
 
 \begin{description}[leftmargin=3cm, style=nextline]
   \item[AI Agent] Autonomous AI system with multi-step task execution, tool use, and goal persistence
-  \item[BDT] Biological Design Tool---specialized AI for biology research
-  \item[BSL] Biosafety Level---laboratory containment classification (1--4)
+  \item[BDT] Biological Design Tool, specialized AI for biology research
+  \item[BSL] Biosafety Level, laboratory containment classification (1--4)
   \item[CRISPR] Gene editing technology
   \item[DURC] Dual-Use Research of Concern
   \item[Gene Drive] Genetic system designed to spread modifications faster than normal inheritance
@@ -2371,7 +2448,7 @@ Gene Drives & High & Low & Very Difficult & Sig. Increasing \\
   \item[Select Agent] CDC/USDA regulated pathogens
   \item[Tacit Knowledge] Skills that cannot be easily transferred through instruction
   \item[Uplift] Degree AI improves non-expert capability on dangerous tasks
-  \item[VLM] Vision-Language Model---AI processing both visual and textual information
+  \item[VLM] Vision-Language Model, AI processing both visual and textual information
 \end{description}
 
 \section{Defense Investment Priority Map}
@@ -2386,11 +2463,11 @@ Gene Drives & High & Low & Very Difficult & Sig. Increasing \\
 \toprule
 \textbf{Stage} & \textbf{AI Uplift Level} & \textbf{Defender Priority} \\
 \midrule
-1. Planning/Research & High & \textbf{HIGH}---AI-assisted threat detection \\
-2. Acquisition & Medium & MEDIUM---Financial monitoring \\
-3. Synthesis/Production & Medium-High & \textbf{MEDIUM-HIGH}---Synthesis screening \\
-4. Weaponization & Medium & MEDIUM---Limited intervention opportunity \\
-5. Deployment & Medium-High & \textbf{MEDIUM-HIGH}---Environmental detection \\
+1. Planning/Research & High & \textbf{HIGH}, AI-assisted threat detection \\
+2. Acquisition & Medium & MEDIUM, Financial monitoring \\
+3. Synthesis/Production & Medium-High & \textbf{MEDIUM-HIGH}, Synthesis screening \\
+4. Weaponization & Medium & MEDIUM, Limited intervention opportunity \\
+5. Deployment & Medium-High & \textbf{MEDIUM-HIGH}, Environmental detection \\
 \bottomrule
 \end{tabular}
 \end{center}
@@ -2496,7 +2573,7 @@ No non-state actor has come close & & \\
 \midrule
 Stuxnet demonstrated code$\to$physical harm & Critical infrastructure increasingly hardened & How many facilities remain vulnerable? \\
 ICS/SCADA vulnerabilities are known & Air-gapping and redundancy are standard & Will AI improve ICS exploitation capabilities? \\
-No synthesis required---existing materials weaponized & Attribution after cyber attack is difficult & What's the actual attack surface for BSL-4/chem plants? \\
+No synthesis required; existing materials weaponized & Attribution after cyber attack is difficult & What's the actual attack surface for BSL-4/chem plants? \\
 AI could assist reconnaissance and exploitation & Few public examples of successful ICS attacks & \\
 \bottomrule
 \end{tabular}
@@ -2629,7 +2706,8 @@ When citing this document:
 \textbf{Distribution}: & Public (open-source) \\
 \textbf{Approved By}: & Andrew Showers \\
 \textbf{Document ID}: & ETRA-2026-WMD-001 \\
-\textbf{Version}: & 2.0 \\
+\textbf{Version}: & 2.1 (July 2026) \\
+\textbf{Revision Note}: & \parbox[t]{11cm}{\raggedright v2.1 refreshes the model and policy landscape to mid-2026 (CB-1/CB-2 thresholds; EO 14110 revocation and successors; 2025 synthesis-screening framework; UK AI Security Institute; EU AI Act GPAI), corrects methodology provenance to a synthesis of published work, reconciles the risk equation and probability estimates, splits the financing/procurement material into its own section, and expands the radiological analysis.} \\
 \textbf{Related Documents}: & ETRA-2026-ESP-001 (Espionage Operations) \\
 & ETRA-2025-AEA-001 (Economic Actors) \\
 & ETRA-2025-FIN-001 (Financial Integrity) \\


### PR DESCRIPTION
## Summary

Editorial revision of the **AI Agents and WMD Proliferation** projection to **v2.1**, updating both the canonical Markdown and the LaTeX rendering. The revision refreshes the report to the mid-2026 landscape and resolves the correctness and consistency issues identified in an editorial review.

Markdown is treated as the canonical source and the LaTeX as its typeset rendering; the two are now back in parity. The LaTeX compiles cleanly (63-page PDF, no errors, fewer overfull boxes than before).

## What changed

**Mid-2026 refresh (with citations)**
- Model and policy landscape updated: Claude Fable 5 / Mythos 5 and the **CB-1/CB-2 capability-threshold framework**, Opus 4.8, DeepSeek V4 / Qwen 3.5 / Kimi K2.6; EO 14110 revocation plus EO 14179 and the AI Action Plan; the May 2025 bio-research EO and the 2025 nucleic-acid synthesis screening framework; UK AI Security Institute; EU AI Act GPAI obligations.
- Added measured-uplift evidence from published 2026 evaluations (generalist-vs-specialist tabletop, the RAND 2024-to-2026 trajectory, persistent failure modes) and a real-world graduated-access governance example.

**Correctness and integrity**
- Corrected the Methodology provenance to a synthesis of published work (no first-party consultation or exercises); added a Limitations and Positionality note.
- Reconciled the risk equation to one canonical five-factor form used everywhere, and reconciled the bottom-up vs. scenario-prior probabilities (the old cumulative figure was a units error).
- Added a lightweight footnote citation apparatus for the checkable claims and fixed the inconsistent RAND report title.

**Structure and accessibility**
- Split the former cyber-physical section into distinct **Cyber-Physical Convergence** and **Proliferation Financing and Procurement Obfuscation** sections; renumbered sections and the table of contents; updated all inline cross-references.
- Expanded the radiological analysis (IAEA source categories, Code of Conduct, orphan sources).
- Added barrier/limitation columns to capability tables and converted the ASCII-art boxes to accessible tables.
- Added a revision history and brought the metadata blocks to parity.
- Removed em-dashes for house style.

## Verification

- LaTeX builds with a clean two-pass `pdflatex` run: 63 pages, no errors, no undefined references.
- Markdown and LaTeX confirmed consistent on section numbering, cross-references, the CB-1/CB-2 material, and metadata.
- No em-dashes remain in either file.

## Notes for review

- Historical figures were annotated with footnotes pointing to their sources but were not each independently re-verified against primary sources; the footnotes mark where to check.

Generated with [Claude Code](https://claude.com/claude-code)
