### PR TITLE
ci(main): allow 1.5h for docker image build, skip it on releases

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -544,13 +544,20 @@ jobs:
   build-images:
     name: Build Docker Images
     needs: [format-check, basic-lint, full-lint, test-suite, mcp-validation, detect-changes]
+    # Skip on tag pushes (releases). These images are built only to validate the
+    # Dockerfiles + compose health -- they use push: false and are torn down at the
+    # end of the job (never published). The tagged commit already passed this same
+    # validation on main, and the release artifacts (wheels, binaries, PDFs) do not
+    # depend on these images. Skipping here avoids ~45+ min of redundant work per release.
     if: >-
       always() && !cancelled() &&
+      !startsWith(github.ref, 'refs/tags/v') &&
       (needs.detect-changes.outputs.docker_changed == 'true' ||
        needs.detect-changes.outputs.mcp_changed == 'true' ||
        needs.detect-changes.outputs.python_changed == 'true')
     runs-on: self-hosted
-    timeout-minutes: 45  # Increased timeout for arm64 builds
+    # arm64 image builds routinely exceed 45 min; allow 1.5h so the job does not time out.
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
@@ -1056,7 +1063,10 @@ jobs:
   # Stage 15: Create GitHub Release
   create-release:
     name: Create GitHub Release
-    needs: [build-python-wheels, build-rust-binaries, build-latex-docs, build-images, integration-tests]
+    # Depends only on the jobs that actually produce release artifacts. build-images
+    # and integration-tests are skipped on tag pushes (see build-images), so gating the
+    # release on them would skip the release entirely.
+    needs: [build-python-wheels, build-rust-binaries, build-latex-docs]
     if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.create_release == 'true'
     runs-on: self-hosted
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

The `build-images` job in Main CI routinely exceeds its 45-minute timeout on the arm64 self-hosted runner. This raises the timeout and eliminates the largest source of wasted time — running the image build during releases, where it is redundant.

## Changes (`.github/workflows/main-ci.yml`)

- **Timeout 45m → 90m** on `build-images` to give arm64 builds enough headroom.
- **Skip `build-images` on tag-push releases** (`!startsWith(github.ref, 'refs/tags/v')`). These images are built with `push: false` and torn down at the end of the job (`docker compose down --rmi local`) — they are **never published**. On a release the tagged commit already passed this exact validation on `main`, and the release artifacts (wheels, Rust binaries, PDFs) do not depend on them. This removes ~45+ min of redundant work per release.
- **Decouple `create-release` from `build-images` and `integration-tests`.** Since `build-images` now skips on tag pushes (and `integration-tests` depends on it), leaving them in `create-release`'s `needs` would have skipped the release itself. `create-release` now depends only on the jobs that produce release artifacts (`build-python-wheels`, `build-rust-binaries`, `build-latex-docs`).

## Safety notes

- `deploy` and `notify` use `always()`, so a skipped `build-images` does not block them; `deploy` is `main`-push only and unaffected.
- The CI summary already renders a skipped state, so releases will correctly show "Docker Build: skipped".
- On normal `main` branch pushes, `build-images` and `integration-tests` run exactly as before.

## Follow-up (not in this PR)

The `build-images` job has a double-build: the 5 `docker/build-push-action` steps use the buildx docker-container builder (own cache), while the trailing health-check step (`build: 'true'`) rebuilds `mcp-code-quality`/`mcp-content-creation`/`mcp-gaea2` via `docker compose build` on the default builder, which cannot reuse the buildx cache. Consolidating these could cut the job time further.

Generated with [Claude Code](https://claude.com/claude-code)
